### PR TITLE
Link from DHCP to Forwarder container was missing.

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -107,6 +107,7 @@ forwarder:
     service: forwarder
   links:
     - consul:consul
+    - dhcp:dhcp
 
 node:
   extends:


### PR DESCRIPTION
This was causing bringup failures at Mesosphere, but not in my local env for some reason.