### PR TITLE
Forwarder dhcp choice

### DIFF
--- a/compose/common.env
+++ b/compose/common.env
@@ -1,13 +1,47 @@
+#
+# Initial database user and password
+#
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=cowcow
+
+#
+# Consul parameters
+#
 CONSUL_ENCRYPT=NMXDBhIgIN4naRrrYDt/Qg==
 CONSUL_M_ACL=f91b0ec7-777b-4f95-a4fd-12e28b0761ba
 CONSUL_DC=rebar
-GOMAXPROCS=4
-BASE_DOMAINNAME=local.neode.org
-THE_LOCAL_NETWORK=
-FORWARDER_IP=192.168.124.11/24
 
+#
+# Make go programs happy
+#
+GOMAXPROCS=4
+
+#
+# Starting domain name
+#
+BASE_DOMAINNAME=local.neode.org
+
+#
+# Should the dhcp/provisioner have an admin address.
+#
+THE_LOCAL_NETWORK=
+
+#
+# Externally accessible address for this system.
+#
+EXTERNAL_IP=192.168.124.11/24
+#EXTERNAL_IP=192.168.99.100/24
+
+#
+# Empty means forwarder is off.
+#
+FORWARDER_IP=192.168.124.11/24
+#FORWARDER_IP=
+
+#
+# Forwarder Variables
+#
 # Should we run NTP and if so should it point to something
 RUN_NTP=YES
 EXTERNAL_NTP_SERVER=
+

--- a/compose/config-dir/postgres/initdb.d/01-rebar-user.sh
+++ b/compose/config-dir/postgres/initdb.d/01-rebar-user.sh
@@ -1,4 +1,3 @@
-set -x
 set -e
 
 # Set up area protection

--- a/compose/config-dir/postgres/initdb.d/02-goiardi-user.sh
+++ b/compose/config-dir/postgres/initdb.d/02-goiardi-user.sh
@@ -1,4 +1,3 @@
-set -x
 set -e
 
 password=fred # GREG: SecureRandom.base64.gsub('=','3')

--- a/compose/docker-compose-common.yml
+++ b/compose/docker-compose-common.yml
@@ -1,6 +1,4 @@
 
-# -recursor=dns
-
 consul:
   image: progrium/consul
   command: -config-dir=/etc/consul.d -data-dir=/tmp/consul -server -bootstrap -ui-dir /ui 
@@ -11,20 +9,11 @@ consul:
   ports:
     - "8500:8500"
 
-#registrator:
-#  image: gliderlabs/registrator
-#  command: consul://consul:8500
-#  volumes:
-#    - /var/run/docker.sock:/tmp/docker.sock
-
 postgres:
   image: digitalrebar/dr_postgres
   volumes:
     - ./config-dir/consul/client-default.json:/etc/consul.d/default.json
     - ./config-dir/postgres/initdb.d:/docker-entrypoint-initdb.d
-#  environment:
-#    SERVICE_NAME: rebar-database
-#    SERVICE_TAGS: postgres
   env_file:
     - ./common.env
 
@@ -53,6 +42,13 @@ rebar_api:
   env_file:
     - ./common.env
 
+ntp:
+  image: digitalrebar/dr_ntp
+  volumes:
+    - ./config-dir/consul/client-default.json:/etc/consul.d/default.json
+  env_file:
+    - ./common.env
+
 dns:
   image: digitalrebar/dr_dns
   volumes:
@@ -63,25 +59,13 @@ dns:
     - ./common.env
 
 dhcp:
-  image: digitalrebar/dr_dhcp
+  image: digitalrebar/dr_rebar_dhcp
   privileged: true
   volumes:
     - ./config-dir/consul/client-default.json:/etc/consul.d/default.json
     - ./data-dir/node:/etc/rebar-data
   env_file:
     - ./common.env
-
-#cobbler:
-#  image: digitalrebar/dr_cobbler
-#  volumes:
-#    - ./config-dir/consul/client-default.json:/etc/consul.d/default.json
-#  env_file:
-#    - ./common.env
-#  ports:
-#    - "69/udp:69/udp"
-#    - "80:80"
-#    - "443:443"
-#    - "25151:25151"
 
 provisioner:
   image: digitalrebar/dr_provisioner
@@ -97,8 +81,6 @@ elasticsearch:
   image: elasticsearch
   volumes:
     - ./config-dir/elasticsearch:/usr/share/elasticsearch/config
-# MAC OS ISSUE WITH THIS ONE!
-#    - ./data-dir/elasticsearch:/usr/share/elasticsearch/data
 
 logstash:
   image: logstash

--- a/compose/docker-compose-no-forwarder.yml
+++ b/compose/docker-compose-no-forwarder.yml
@@ -17,7 +17,8 @@ webproxy:
     service: webproxy
   links:
     - consul:consul
-    - forwarder:forwarder
+  ports:
+    - "3128:3128"
 
 goiardi:
   extends:
@@ -26,6 +27,8 @@ goiardi:
   links:
     - consul:consul
     - postgres:database
+  ports:
+    - "4646:4646"
 
 rebar_api:
   extends:
@@ -35,7 +38,18 @@ rebar_api:
     - consul:consul
     - postgres:database
     - goiardi:goiardi
-    - forwarder:forwarder
+  ports:
+    - "3000:3000"
+
+ntp:
+  extends:
+    file: docker-compose-common.yml
+    service: ntp
+  links:
+    - consul:consul
+  ports:
+    - "123/udp:123/udp"
+    - "123:123"
 
 dns:
   extends:
@@ -43,16 +57,16 @@ dns:
     service: dns
   links:
     - consul:consul
-    - forwarder:forwarder
+  ports:
+    - "53/udp:53/udp"
 
 dhcp:
   extends:
     file: docker-compose-common.yml
     service: dhcp
-  net: "forwarder"
   links:
     - consul:consul
-    - forwarder:forwarder
+  net: "host"
 
 provisioner:
   extends:
@@ -60,7 +74,9 @@ provisioner:
     service: provisioner
   links:
     - consul:consul
-    - forwarder:forwarder
+  ports:
+    - "69/udp:69/udp"
+    - "8091:8091"
 
 elasticsearch:
   extends:
@@ -92,17 +108,9 @@ cadvisor:
     file: docker-compose-common.yml
     service: cadvisor
 
-forwarder:
-  extends:
-    file: docker-compose-common.yml
-    service: forwarder
-  links:
-    - consul:consul
-
 node:
   extends:
     file: docker-compose-common.yml
     service: node
   links:
     - rebar_api:rebar_api
-    - forwarder:forwarder

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -49,7 +49,7 @@ dhcp:
   extends:
     file: docker-compose-common.yml
     service: dhcp
-  net: "forwarder"
+  net: "container:forwarder"
   links:
     - consul:consul
     - forwarder:forwarder


### PR DESCRIPTION
Allow for the services to be internally provided (service name has internal- and is exposed by the forwarder) or externally provided (ports are mapped to the host).  The system watches the FORWARDER_IP and EXTERNAL_IP to determine route changes and service names.

By default, the system assumes that FORWARDER_IP and EXTERNAL_IP are the same and that a FORWARDER will be created.

A new compose file is added, docker-compose-no-forwarder.yml, that assumes that FORWARDER_IP is not set and EXTERNAL_IP is an IP on the host.  It will NOT run a forwarder and expose the ports through the host.

This turns off some logging and cleans up the compose files.