### PR TITLE
DHCP doesn't need links and some versions of compose gets

### DIFF
--- a/compose/yaml_templates/provisioner.yml
+++ b/compose/yaml_templates/provisioner.yml
@@ -3,8 +3,6 @@ dhcp:
   extends:
     file: docker-compose-common.yml
     service: dhcp
-  links:
-    - consul:consul
 {{ START ACCESS_MODE==FORWARDER }}
   net: "container:forwarder"
 {{ END ACCESS_MODE==FORWARDER }}


### PR DESCRIPTION
upset with the host based networking and links.