### PR TITLE
add correct License information

### DIFF
--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,0 +1,207 @@
+RACKN LIMITED USE SOFTWARE END USER LICENSE AGREEMENT
+=====================================================
+
+*Note: This license applies to extensions, related components and software supporting the Apache 2 licensed Digital Rebar project.  It does not supersede the Digital Rebar license.*
+ 
+BY CLICKING ON THE “I AGREE”, “I ACCEPT”, “CLONE” OR SUCH SIMILAR BUTTON OR
+LINK AS MAY BE DESIGNATED FOR PURPOSES OF INITIATING THE DOWNLOAD FROM THE
+INTERNET OF THE RACKN ENTERPRISE SOFTWARE PRODUCT (THE "APPLICATION") AND
+USING THE APPLICATION YOU AGREE TO BE LEGALLY BOUND BY THE INCLUDED LICENSE
+TERMS AND CONDITIONS.
+ 
+RACKN® is SPYWARE-FREE AND NO REGISTRATION OR PERSONAL INFORMATION IS REQUIRED
+FOR USE.
+ 
+All rights not expressly granted hereunder are expressly reserved by RACKN®
+ 
+.. contents:: Table Contents   :depth: 1
+
+OWNERSHIP
+---------
+ 
+You acknowledge and agree that you are receiving a copy of the Application by
+license only and not by sale and that the "first sale" doctrine of 17 U.S.C.
+§109 does not apply to your receipt or use of the Application. You acknowledge
+that the Application, including all code, content, protocols, software,
+documentation and all other conceivable intellectual property rights related
+to and in conjunction with the Application are provided to you by RACKN and
+are RACKN property or the property of RACKN licensors, and are protected by
+U.S. and international copyright, trademark, patent and proprietary rights and
+international treaty provisions and all applicable law, such as the Lanham
+Act, relating to Intellectual Property Rights. "Intellectual Property Rights"
+means, collectively, rights under patent, trademark, copyright and trade
+secret laws, and any other intellectual property or proprietary rights
+recognized in any country or jurisdiction worldwide, including, without
+limitation, moral or similar rights. You may not delete, alter, or remove any
+copyright, trademark, or other proprietary rights notice RACKN has placed on
+the Application.
+ 
+LICENSE
+-------
+
+RackN and its licensors provide the Application to you and grants you a non-
+exclusive, nontransferable license to where the Application is to be used at
+home or business, you may install and use the Application on any computer or
+computers of the type identified on the website.
+ 
+RackN reserves the right to add additional features or functions to the
+existing Application. You understand that RackN may require your review and
+acceptance of RackN then-current privacy policy and/or end user license
+agreement before you will be permitted a limited license for any subsequent
+versions of the Application. You acknowledge and agree that RackN has no
+obligation to make available to you any subsequent versions of the
+Application.
+ 
+It is understood and agreed that while the Application may or may not be “copy
+protected,” you, as the Licensee, shall not copy the Application into any
+machine-readable or printed form except for archival or for backup purposes,
+nor shall you modify the Application and/or merge it into another computer
+program.
+ 
+It is further understood that the Application is primarily for evaluation and
+non-commercial use. Non-commercial use of the Application, for purpose of this
+agreement, includes uses on or in conjunction with: personal and corporate
+products, professional services and development work in which revenue is
+realized. The Application may not be offered for sale, used in conjunction
+with goods/services being offered for sale, or used in advertising without the
+express written consent of RackN. Where depiction of images created using the
+Application occurs not on a Web site and where express consent is granted by
+RackN in a written agreement separate and distinct in form and purpose from
+this Limited Use End User License Agreement, the Application may be used at or
+by a business for commercial purposes in accordance with the separate and
+distinct express written agreement. You agree not to modify, copy, distribute,
+transmit, display, perform, reproduce, publish, license, create derivative
+works from, transfer, or sell any content, including, without limitation,
+copyright works, information, software, products or services.
+ 
+If you the Application, you agree to: a. not use the Application to disparage
+RackN, its suppliers, products, partners, services and investors for
+promotional goods or for products which, in RackN sole judgment, may diminish
+or otherwise damage RackN goodwill in the Application including but not
+limited to uses which could be deemed under applicable law to a. not use the
+Application in any manner that may disparage the Application or impair the
+validity, scope, title or goodwill of RackN in the Application; b. acknowledge
+that the Application and any related Trademarks shall not be modified to
+infringe the copyright, trademark or common law rights of any person or
+entity, and; d. acknowledge that nothing contained in any material produced by
+you that incorporates the Application or any related Trademarks will
+constitute a libel or slander against, or violate or infringe upon any right,
+common law or otherwise, of any kind or nature whatsoever, of any person or
+entity, including, without limitation, any right of privacy or publicity.
+
+
+REVERSE ENGINEERING
+-------------------
+
+RackN retains all right, title, and interest in and to the Application, and
+any rights not granted to you herein are reserved by RackN. You may not
+reverse engineer, disassemble, decompile, or translate the Application, or
+otherwise attempt to derive the source code of the Application, except to the
+extent allowed under any applicable law. If applicable law permits such
+activities, any information so discovered must be promptly disclosed to RackN
+and shall be deemed to be the confidential proprietary information of RackN.
+ 
+TERM
+----
+
+This license is effective until terminated. You may terminate it at any time
+by destroying the Application together with all copies in any form. This
+license will also terminate upon conditions set forth elsewhere in this
+agreement or if you fail to comply with any term or condition of this
+agreement. You agree that upon such termination you will destroy the
+Application together with all copies in any form.
+
+JURISDICTION
+------------
+
+The following are terms of a legal agreement between you and RackN. By
+accessing, downloading from the Internet, uploading from any portable media
+storage device or installing the Application, you acknowledge that you have
+read, understood, and agree to be bound by these terms and to comply with all
+applicable laws and regulations, including U.S. export laws and regulations
+including those which apply to export of data. If you do not agree to these
+terms, do not use the Application. The material provided in the Application is
+protected by law, including, but not limited to, United States Copyright Law
+and international treaties. Those who choose to use the Application do so on
+their own initiative and are responsible for compliance with applicable laws.
+Any claim relating to, and the use of, the Application and the materials
+contained therein is governed by the laws of the State of New York.
+ 
+INDEMNIFICATION
+---------------
+
+You hereby agree to indemnify, defendingnd and hold RackN, its affiliates,
+subsidiaries, parents, shareholders, directors, officers, employees, agents,
+contractors, licensors, and representatives harmless from and against any and
+all claims, loss, damage, tax, liability and/or expense that may be incurred
+by RackN, its affiliates, subsidiaries, parents, shareholders, directors,
+officers, employees, agents, contractors, licensors, and representatives
+arising out of or in connection with the performance of its duties as
+described in this Agreement including the legal costs, fees and expenses of
+defending itself against any claim by any or all of the parties to any RackN
+transaction and/or by any other person and/or as a result of your taking any
+action or refraining from taking any action or instituting or defending any
+action or legal proceeding.
+ 
+You further agree to indemnify and hold RackN, its affiliates, subsidiaries,
+parents, shareholders, directors, officers, employees, agents, contractors,
+licensors, and representatives harmless from any claim or demand, including
+reasonable attorneys' fees, made by any third party due to or arising out of
+your use of the Application, your violation of the terms and conditions of
+this Licensing Agreement, or the infringement by you, or other user(s) of the
+Application using your computer, of any intellectual property or other right
+of any person or entity.
+ 
+DISCLAIMER AND LIMITATIONS OF REMEDIES
+--------------------------------------
+
+RACKN, THE MAKER OF THE APPLICATION, MAKES NO WARRANTIES THAT THE IMAGES
+CONTAINED  HEREIN ARE FREE FROM INFRINGEMENT OF COPYRIGHT, OR ANY OTHER FORM
+OF INTELLECTUAL  PROPERTY. THE USER ASSUMES ALL LEGAL RISKS RELATED TO
+DOWNLOADED/UPLOADED IMAGES. TO  THE MAXIMUM EXTENT PERMITTED BY APPLICABLE
+LAW, TUBEHEAD AND ITS SUPPLIERS PROVIDE TO  YOU THE APPLICATION, AND ANY (IF
+ANY) SUPPORT SERVICES RELATED TO THE APPLICATION  ("SUPPORT SERVICES") AS IS
+AND WITH ALL FAULTS; AND TUBEHEAD AND ITS SUPPLIERS HEREBY  DISCLAIM WITH
+RESPECT TO THE APPLICATION AND SUPPORT SERVICES ALL WARRANTIES AND
+CONDITIONS, WHETHER EXPRESS, IMPLIED OR STATUTORY, INCLUDING, BUT NOT LIMITED
+TO, ANY (IF  ANY) WARRANTIES OR CONDITIONS OF OR RELATED TO: TITLE, NON-
+INFRINGEMENT,  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, LACK OF
+VIRUSES, ACCURACY OR  COMPLETENESS OF RESPONSES, ACCURACY OR COMPLETENESS OF
+FACTUAL INFORMATION, FITNESS  FOR ANY SPECIFIC CURRICULUM OR AGE GROUP,
+RESULTS, LACK OF NEGLIGENCE OR LACK OF  WORKMANLIKE EFFORT, QUIET ENJOYMENT,
+QUIET POSSESSION, AND CORRESPONDENCE TO DESCRIPTION.  THE ENTIRE RISK ARISING
+OUT OF USE OR PERFORMANCE OF THE APPLICATION, COMPONENTS AND ANY  SUPPORT
+SERVICES REMAINS WITH YOU.
+ 
+EXCLUSION OF INCIDENTAL, CONSEQUENTIAL, AND CERTAIN OTHER DAMAGES. TO THE
+MAXIMUM  EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT SHALL TUBEHEAD OR ITS
+SUPPLIERS BE LIABLE  FOR ANY SPECIAL, INCIDENTAL, INDIRECT, OR CONSEQUENTIAL
+DAMAGES WHATSOEVER (INCLUDING,  BUT NOT LIMITED TO, DAMAGES FOR: LOSS OF
+PROFITS, LOSS OF CONFIDENTIAL OR OTHER  INFORMATION, BUSINESS INTERRUPTION,
+PERSONAL INJURY, EMOTIONAL DISTRESS, LOSS OF PRIVACY,  FAILURE TO MEET ANY
+DUTY (INCLUDING OF GOOD FAITH OR OF REASONABLE CARE), NEGLIGENCE,  AND ANY
+OTHER PECUNIARY OR OTHER LOSS WHATSOEVER) ARISING OUT OF OR IN ANY WAY RELATED
+TO THE USE OF OR INABILITY TO USE THE APPLICATION OR THE SUPPORT SERVICES, OR
+THE PROVISION  OF OR FAILURE TO PROVIDE SUPPORT SERVICES, OR OTHERWISE UNDER
+OR IN CONNECTION WITH ANY  PROVISION OF THIS SUPPLEMENTAL END USER LICENSE
+AGREEMENT (EULA), EVEN IF TUBEHEAD OR ANY  SUPPLIER HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+ 
+LIMITATION OF LIABILITY AND REMEDIES. NOT WITHSTANDING ANY DAMAGES THAT YOU
+MIGHT INCUR  FOR ANY REASON WHATSOEVER (INCLUDING, WITHOUT LIMITATION, ALL
+DAMAGES REFERENCED  ABOVE AND ALL DIRECT OR GENERAL DAMAGES), THE ENTIRE
+LIABILITY OF TUBEHEAD AND ANY OF ITS  SUPPLIERS UNDER ANY PROVISION OF THIS
+SUPPLEMENTAL EULA AND YOUR EXCLUSIVE REMEDY FOR  ALL OF THE FOREGOING SHALL BE
+LIMITED TO THE REPLACEMENT OF THE APPLICATION. THE FOREGOING  LIMITATIONS,
+EXCLUSIONS, AND DISCLAIMERS SHALL APPLY TO THE MAXIMUM EXTENT PERMITTED BY
+APPLICABLE LAW, EVEN IF ANY REMEDY FAILS ITS ESSENTIAL PURPOSE.
+ 
+If, for any reason, any part of this Agreement is deemed legally improper,
+inapplicable or  inoperative, the remainder of the parts comprising the
+entirety of the Agreement shall remain  legally proper, applicable and
+operable. This Agreement grants permission only for the  allowances described
+above and does not grant any additional rights for any copyright(s),
+trademark(s), patent(s), trade secret(s), or other forms of intellectual
+property/proprietary  rights belonging to RackN Inc., the maker of RackN
+Enterprise.
+ 


### PR DESCRIPTION
This license expresses RackN intent around the deploy components we've added to Digital Rebar.  It will be copied to other RackN extensions.

