### PR TITLE
Fixed selinux installer to use Docker's repo instead of centos

### DIFF
--- a/tasks/docker-linux.yml
+++ b/tasks/docker-linux.yml
@@ -10,10 +10,10 @@
     command: sudo /tmp/docker.sh
     args:
       creates: /usr/bin/docker
-  - name: install docker-selinux
+  - name: install docker-engine-selinux
     yum: name={{ item }} state=latest
     with_items:
-      - docker-selinux
+      - docker-engine-selinux
     when: (ansible_distribution == "RedHat" or ansible_distribution == "CentOS") and ansible_distribution_major_version == "7"
 
   - name: restart docker service


### PR DESCRIPTION
Fixed issue with install trying to use the centos docker-selinux package instead of the Docker repo's selinux package (docker-engine-selinux), this fixes the install from failing due to package conflicts.