### PR TITLE
Consul has to be exposed on the host for DHCP

### DIFF
--- a/compose/yaml_templates/base.yml
+++ b/compose/yaml_templates/base.yml
@@ -3,6 +3,8 @@ consul:
   extends:
     file: docker-compose-common.yml
     service: consul
+  ports:
+    - "127.0.0.1:8500:8500"
 
 postgres:
   extends:


### PR DESCRIPTION
in host mode.  We can bind it to localhost to
have some security.