### PR TITLE
account for prereq package differences in new Debian versions

### DIFF
--- a/tasks/base-ubuntu1510.yml
+++ b/tasks/base-ubuntu1510.yml
@@ -1,0 +1,28 @@
+---
+  - name: Update repos (was not working from apt:)
+    command: sudo apt-get update -y
+  - name: Install Prereqs [SLOW]
+    apt: name={{ item }} state=latest
+    with_items:
+      - git
+      - screen
+      - qemu-kvm
+      - libvirt-bin
+      - ubuntu-vm-builder
+      - bridge-utils
+      - ruby-dev
+      - make
+      - curl
+      - wget
+    sudo: yes
+  - name: gem install kvm slaves
+    command: sudo gem install json net-http-digest_auth
+    args:
+      creates: /var/lib/gems/1.9.1/cache/json-1.8.3.gem
+    sudo: yes
+  - name: stop apparmor
+    command: sudo service apparmor teardown
+    sudo: yes
+  - name: remove apparmor
+    command: sudo update-rc.d -f apparmor remove
+    sudo: yes

--- a/tasks/base.yml
+++ b/tasks/base.yml
@@ -2,7 +2,9 @@
 ---
   - include: base-centos.yml
     when: ansible_os_family == "RedHat"
+  - include: base-ubuntu1510.yml
+    when: ansible_os_family == "Debian" and ansible_distribution_version|int >= 7
   - include: base-ubuntu1404.yml
-    when: ansible_os_family == "Debian"
+    when: ansible_os_family == "Debian" and ansible_distribution_version|int < 7
   - include: base-darwin.yml
     when: ansible_os_family == "Darwin"

--- a/tasks/base.yml
+++ b/tasks/base.yml
@@ -3,8 +3,8 @@
   - include: base-centos.yml
     when: ansible_os_family == "RedHat"
   - include: base-ubuntu1510.yml
-    when: ansible_os_family == "Debian" and ansible_distribution_version|int >= 7
+    when: ansible_os_family == "Debian" and ansible_lsb.major_release == "15"
   - include: base-ubuntu1404.yml
-    when: ansible_os_family == "Debian" and ansible_distribution_version|int < 7
+    when: ansible_os_family == "Debian" and ansible_lsb.major_release != "15"
   - include: base-darwin.yml
     when: ansible_os_family == "Darwin"

--- a/tasks/compose.yml
+++ b/tasks/compose.yml
@@ -91,14 +91,6 @@
     args:
       creates: "{{home_dir.stdout}}/digitalrebar/deploy/compose/config-dir/api/config/ssh_keys/setup-0.key"
 
-  - name: test for /vagrant
-    stat: path=/vagrant
-    register: vagrant_dir_present
-
-  - name: allow docker access after reboot
-    command: sudo usermod -a -G docker vagrant
-    when: vagrant_dir_present.stat.exists == True
-
   - name: Create rebar group
     group: name=rebar
     when: ansible_os_family != "Darwin"

--- a/tasks/docker-linux.yml
+++ b/tasks/docker-linux.yml
@@ -25,7 +25,12 @@
     command: sudo curl -L https://github.com/docker/compose/releases/download/1.5.0/docker-compose-{{ ansible_system }}-{{ ansible_userspace_architecture }} -o /usr/local/bin/docker-compose
     args:
       creates: /usr/local/bin/docker-compose
+
   - name: Chmod Docker Compose
     command: sudo chmod +x /usr/local/bin/docker-compose
-  - name: allow docker access (without reboot)
+
+  - name: Allow docker access (without reboot)
     command: sudo chmod 666 /var/run/docker.sock
+
+  - name: Allow docker access after reboot
+    command: "sudo usermod -a -G docker $USER"


### PR DESCRIPTION
Using 15.10 had different package (ruby-dev) than the current 14.04 stable list.