### PR TITLE
Have Consul always run in host mode.

### DIFF
--- a/compose/config-dir/consul/client-default.json
+++ b/compose/config-dir/consul/client-default.json
@@ -4,4 +4,3 @@
   "encrypt": "NMXDBhIgIN4naRrrYDt/Qg==",
   "disable_remote_exec": true
 }
-

--- a/compose/config-dir/consul/server-default.json
+++ b/compose/config-dir/consul/server-default.json
@@ -1,12 +1,11 @@
 {
-  "client_addr": "0.0.0.0",
-  "datacenter": "digitalrebar",
-  "domain": "consul",
-  "acl_datacenter": "digitalrebar",
-  "acl_master_token": "f91b0ec7-777b-4f95-a4fd-12e28b0761ba",
-  "acl_default_policy": "allow",
-  "acl_down_policy": "allow",
-  "encrypt": "NMXDBhIgIN4naRrrYDt/Qg==",
-  "disable_remote_exec": true
+    "datacenter": "digitalrebar",
+    "domain": "consul",
+    "acl_datacenter": "digitalrebar",
+    "acl_master_token": "f91b0ec7-777b-4f95-a4fd-12e28b0761ba",
+    "acl_default_policy": "allow",
+    "acl_down_policy": "allow",
+    "encrypt": "NMXDBhIgIN4naRrrYDt/Qg==",
+    "disable_remote_exec": true
 }
 

--- a/compose/docker-compose-common.yml
+++ b/compose/docker-compose-common.yml
@@ -1,9 +1,9 @@
 
 consul:
-  image: progrium/consul
-  command: -config-dir=/etc/consul.d -data-dir=/tmp/consul -server -bootstrap -ui-dir /ui 
+  image: gliderlabs/consul
   volumes:
     - ./config-dir/consul/server-default.json:/etc/consul.d/default.json
+    - ./config-dir/consul/server-advertise.json:/etc/consul.d/server-advertise.json
   env_file:
     - ./common.env
     - ./access.env

--- a/compose/yaml_templates/base.yml
+++ b/compose/yaml_templates/base.yml
@@ -3,23 +3,20 @@ consul:
   extends:
     file: docker-compose-common.yml
     service: consul
-  ports:
-    - "127.0.0.1:8500:8500"
+  net: host
+  command: agent -config-dir=/etc/consul.d -data-dir=/tmp/consul -server -bootstrap
 
 postgres:
   extends:
     file: docker-compose-common.yml
     service: postgres
-  links:
-    - consul:consul
 
 webproxy:
   extends:
     file: docker-compose-common.yml
     service: webproxy
-  links:
-    - consul:consul
 {{ START ACCESS_MODE==FORWARDER }}
+  links:
     - forwarder:forwarder
 {{ END ACCESS_MODE==FORWARDER }}
 {{ START ACCESS_MODE==HOST }}
@@ -32,7 +29,6 @@ goiardi:
     file: docker-compose-common.yml
     service: goiardi
   links:
-    - consul:consul
     - postgres:database
 {{ START ACCESS_MODE==FORWARDER }}
     - forwarder:forwarder
@@ -47,7 +43,6 @@ rebar_api:
     file: docker-compose-common.yml
     service: rebar_api
   links:
-    - consul:consul
     - postgres:database
     - goiardi:goiardi
 {{ START ACCESS_MODE==FORWARDER }}
@@ -62,9 +57,8 @@ fogwrap:
   extends:
     file: docker-compose-common.yml
     service: fogwrap
-  links:
-    - consul:consul
 {{ START ACCESS_MODE==FORWARDER }}
+  links:
     - forwarder:forwarder
 {{ END ACCESS_MODE==FORWARDER }}
 {{ START ACCESS_MODE==HOST }}
@@ -76,9 +70,8 @@ packetwrap:
   extends:
     file: docker-compose-common.yml
     service: packetwrap
-  links:
-    - consul:consul
 {{ START ACCESS_MODE==FORWARDER }}
+  links:
     - forwarder:forwarder
 {{ END ACCESS_MODE==FORWARDER }}
 {{ START ACCESS_MODE==HOST }}
@@ -90,9 +83,8 @@ dns:
   extends:
     file: docker-compose-common.yml
     service: dns
-  links:
-    - consul:consul
 {{ START ACCESS_MODE==FORWARDER }}
+  links:
     - forwarder:forwarder
 {{ END ACCESS_MODE==FORWARDER }}
 {{ START ACCESS_MODE==HOST }}
@@ -105,8 +97,6 @@ forwarder:
   extends:
     file: docker-compose-common.yml
     service: forwarder
-  links:
-    - consul:consul
 {{ END ACCESS_MODE==FORWARDER }}
 
 {{ START ACCESS_MODE==HOST }}
@@ -114,8 +104,6 @@ ntp:
   extends:
     file: docker-compose-common.yml
     service: ntp
-  links:
-    - consul:consul
   ports:
     - "123/udp:123/udp"
     - "123:123"

--- a/compose/yaml_templates/provisioner.yml
+++ b/compose/yaml_templates/provisioner.yml
@@ -14,9 +14,8 @@ provisioner:
   extends:
     file: docker-compose-common.yml
     service: provisioner
-  links:
-    - consul:consul
 {{ START ACCESS_MODE==FORWARDER }}
+  links:
     - forwarder:forwarder
 {{ END ACCESS_MODE==FORWARDER }}
 {{ START ACCESS_MODE==HOST }}


### PR DESCRIPTION
This modifies the templates and init_files.sh to allow the Consul
container to always run in host mode.  It tries to be smart about
telling the Consul server what address on the host to advertise to the
other consuls, and complains and dies loudly if it cannot pick one.