### PR TITLE
Don't do extra work if we don't need a provisioner

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -71,42 +71,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     puts "After the system is up, you can start the nodes using `vagrant up /node[1-20]/`"
   end
 
-  config.vm.define "admin", autostart:false do |admin|
-
-    admin.vm.box = BASE_OS_BOX
-
-    # Create a private network, which allows host-only access to the machine
-    # using a specific IP.
-    admin.vm.network "private_network", ip: ADMIN_IP, auto_config: true
-
-    # avoid redownloading large files      
-    FileUtils.mkdir_p "#{ENV['HOME']}/.cache/digitalrebar/tftpboot"
-    admin.vm.synced_folder "#{ENV['HOME']}/.cache/digitalrebar/tftpboot",
-          "/#{ENV['HOME']}/.cache/digitalrebar/tftpboot",
-          type: 'nfs', nfs_udp: false,
-          bsd__nfs_options: [ 'maproot=root:wheel' ],
-          linux__nfs_options: [ 'maproot=root:wheel' ]
-
-    admin.vm.provider "virtualbox" do |vb|
-      vb.memory = "4096"
-      vb.cpus = 4
-    end
-
-    #
-    # Admin nodes eat themselves without swap
-    #
-    admin.vm.provision "shell", path: "scripts/increase_swap.sh"
-
-    admin.vm.provision "ansible" do |ansible|
-      ansible.sudo = true
-      ansible.sudo_user = "root"
-      ansible.playbook = "digitalrebar.yml"
-    end
-
-    puts "To monitor > https://#{ADMIN_IP}:3000 (Digital Rebar)"
-    puts "After the system is up, you can start the nodes using `vagrant up /node[1-20]/`"
-  end
-
   (1..20).each do |i|
     config.vm.define "node#{i}", autostart:false do |slave|
       slave.vm.hostname = "node#{i}.rebar.local"

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -35,7 +35,8 @@
 # If no services are desired, comment out the dr_services: line as well
 #
 dr_services:
-  - --provisioner
+   -
+#  - --provisioner
 
 #
 # Workloads

--- a/tasks/base-centos.yml
+++ b/tasks/base-centos.yml
@@ -8,7 +8,6 @@
       - git
       - curl
       - wget
-      - gcc
       - psmisc
     sudo: yes
   - name: Install Provisioner Prereqs [SLOW]
@@ -20,6 +19,7 @@
       - bridge-utils
       - ruby-devel
       - make
+      - gcc
     sudo: yes
     when: "'--provisioner' in {{dr_services}}"
   - name: Install Provisioner ruby-gems for CentOS/RedHat 6

--- a/tasks/base-centos.yml
+++ b/tasks/base-centos.yml
@@ -6,18 +6,23 @@
     yum: name={{ item }} state=latest
     with_items:
       - git
+      - curl
+      - wget
+      - gcc
+      - psmisc
+    sudo: yes
+  - name: Install Provisioner Prereqs [SLOW]
+    yum: name={{ item }} state=latest
+    with_items:
       - screen
       - qemu-kvm
       - libvirt
       - bridge-utils
       - ruby-devel
       - make
-      - curl
-      - wget
-      - gcc
-      - psmisc
     sudo: yes
-  - name: Install ruby-gems for CentOS/RedHat 6
+    when: "'--provisioner' in {{dr_services}}"
+  - name: Install Provisioner ruby-gems for CentOS/RedHat 6
     yum: name={{ item }} state=latest
     with_items:
       - rubygems

--- a/tasks/base-centos.yml
+++ b/tasks/base-centos.yml
@@ -25,7 +25,9 @@
     sudo: yes
   - name: gem install kvm slaves
     command: sudo gem install json net-http-digest_auth
-  # Docker will put back what it needs - firewalld on Centos7
+    when: "'--provisioner' in {{dr_services}}"
+
+    # Docker will put back what it needs - firewalld on Centos7
   - name: Silly flush of iptables
     command: sudo iptables -F
     ignore_errors: yes

--- a/tasks/base-debian-7.yml
+++ b/tasks/base-debian-7.yml
@@ -5,16 +5,21 @@
     apt: name={{ item }} state=latest
     with_items:
       - git
+      - curl
+      - wget
+    sudo: yes
+  - name: Install Provisioner Prereqs [SLOW]
+    apt: name={{ item }} state=latest
+    with_items:
       - screen
       - qemu-kvm
       - libvirt-bin
       - bridge-utils
       - ruby1.9.1-dev
       - make
-      - curl
-      - wget
     sudo: yes
-  - name: gem install kvm slaves
+    when: "'--provisioner' in {{dr_services}}"
+  - name: Provisioner gem install kvm slaves
     command: sudo gem install json net-http-digest_auth
     args:
       creates: /var/lib/gems/1.9.1/cache/json-1.8.3.gem

--- a/tasks/base-debian-7.yml
+++ b/tasks/base-debian-7.yml
@@ -19,3 +19,4 @@
     args:
       creates: /var/lib/gems/1.9.1/cache/json-1.8.3.gem
     sudo: yes
+    when: "'--provisioner' in {{dr_services}}"

--- a/tasks/base-debian-8.yml
+++ b/tasks/base-debian-8.yml
@@ -21,3 +21,4 @@
     args:
       creates: /var/lib/gems/1.9.1/cache/json-1.8.3.gem
     sudo: yes
+    when: "'--provisioner' in {{dr_services}}"

--- a/tasks/base-debian-8.yml
+++ b/tasks/base-debian-8.yml
@@ -5,18 +5,23 @@
     apt: name={{ item }} state=latest
     with_items:
       - git
+      - curl
+      - wget
+      - gcc
+    sudo: yes
+  - name: Install Provisioner Prereqs [SLOW]
+    apt: name={{ item }} state=latest
+    with_items:
       - screen
       - qemu-kvm
       - libvirt-bin
       - bridge-utils
       - ruby-dev
       - rubygems
-      - gcc
       - make
-      - curl
-      - wget
     sudo: yes
-  - name: gem install kvm slaves
+    when: "'--provisioner' in {{dr_services}}"
+  - name: Provisoner gem install kvm slaves
     command: sudo gem install json net-http-digest_auth
     args:
       creates: /var/lib/gems/1.9.1/cache/json-1.8.3.gem

--- a/tasks/base-debian-8.yml
+++ b/tasks/base-debian-8.yml
@@ -7,7 +7,6 @@
       - git
       - curl
       - wget
-      - gcc
     sudo: yes
   - name: Install Provisioner Prereqs [SLOW]
     apt: name={{ item }} state=latest
@@ -19,6 +18,7 @@
       - ruby-dev
       - rubygems
       - make
+      - gcc
     sudo: yes
     when: "'--provisioner' in {{dr_services}}"
   - name: Provisoner gem install kvm slaves

--- a/tasks/base-ubuntu1404.yml
+++ b/tasks/base-ubuntu1404.yml
@@ -20,6 +20,8 @@
     args:
       creates: /var/lib/gems/1.9.1/cache/json-1.8.3.gem
     sudo: yes
+    when: "'--provisioner' in {{dr_services}}"
+
   - name: stop apparmor
     command: sudo service apparmor teardown
     sudo: yes

--- a/tasks/base-ubuntu1404.yml
+++ b/tasks/base-ubuntu1404.yml
@@ -5,6 +5,12 @@
     apt: name={{ item }} state=latest
     with_items:
       - git
+      - wget
+      - gcc
+    sudo: yes
+  - name: Install Provisioner Prereqs [SLOW]
+    apt: name={{ item }} state=latest
+    with_items:
       - screen
       - qemu-kvm
       - libvirt-bin
@@ -12,10 +18,9 @@
       - bridge-utils
       - ruby1.9.1-dev
       - make
-      - curl
-      - wget
     sudo: yes
-  - name: gem install kvm slaves
+    when: "'--provisioner' in {{dr_services}}"
+  - name: Provisioner gem install kvm slaves
     command: sudo gem install json net-http-digest_auth
     args:
       creates: /var/lib/gems/1.9.1/cache/json-1.8.3.gem

--- a/tasks/base-ubuntu1404.yml
+++ b/tasks/base-ubuntu1404.yml
@@ -6,7 +6,7 @@
     with_items:
       - git
       - wget
-      - gcc
+      - curl
     sudo: yes
   - name: Install Provisioner Prereqs [SLOW]
     apt: name={{ item }} state=latest
@@ -18,6 +18,7 @@
       - bridge-utils
       - ruby1.9.1-dev
       - make
+      - gcc
     sudo: yes
     when: "'--provisioner' in {{dr_services}}"
   - name: Provisioner gem install kvm slaves

--- a/tasks/base-ubuntu1510.yml
+++ b/tasks/base-ubuntu1510.yml
@@ -20,6 +20,8 @@
     args:
       creates: /var/lib/gems/1.9.1/cache/json-1.8.3.gem
     sudo: yes
+    when: "'--provisioner' in {{dr_services}}"
+
   - name: stop apparmor
     command: sudo service apparmor teardown
     sudo: yes

--- a/tasks/base-ubuntu1510.yml
+++ b/tasks/base-ubuntu1510.yml
@@ -5,6 +5,12 @@
     apt: name={{ item }} state=latest
     with_items:
       - git
+      - curl
+      - wget
+    sudo: yes
+  - name: Install Provisioner Prereqs [SLOW]
+    apt: name={{ item }} state=latest
+    with_items:
       - screen
       - qemu-kvm
       - libvirt-bin
@@ -12,10 +18,9 @@
       - bridge-utils
       - ruby-dev
       - make
-      - curl
-      - wget
     sudo: yes
-  - name: gem install kvm slaves
+    when: "'--provisioner' in {{dr_services}}"
+  - name: Provisioner gem install kvm slaves
     command: sudo gem install json net-http-digest_auth
     args:
       creates: /var/lib/gems/1.9.1/cache/json-1.8.3.gem

--- a/tasks/compose.yml
+++ b/tasks/compose.yml
@@ -47,6 +47,8 @@
     args:
       creates: "{{home_dir.stdout}}/.ssh/id_rsa.pub"
 
+  - debug: var=dr_services
+
   - name: Make cache dirs
     command: mkdir -p {{home_dir.stdout}}/.cache/digitalrebar/tftpboot/isos
 


### PR DESCRIPTION
This includes changes to Vagrant that assumes we don't want to setup provisioning hosts w/ Vagrant - we've learned that metal provisioning from Vagrant is very complex because of networking configuration.