### PR TITLE
Add an OS map to the script tools.  This will pass a

### DIFF
--- a/workloads/docker-swarm.sh
+++ b/workloads/docker-swarm.sh
@@ -59,8 +59,10 @@ if [[ $TEARDOWN ]] ; then
 fi
 
 # Wait for the system to converge
-if ! rebar converge ; then
-  die "Admin node did NOT converge to completion"
+if [[ ! $ADMIN_ALREADY_UP ]] ; then
+  if ! rebar converge ; then
+    die "Admin node did NOT converge to completion"
+  fi
 fi
 
 add_provider

--- a/workloads/kubernetes.sh
+++ b/workloads/kubernetes.sh
@@ -107,8 +107,10 @@ if [[ $TEARDOWN ]] ; then
 fi
 
 # Wait for the system to converge
-if ! rebar converge ; then
-  die "Admin node did NOT converge to completion"
+if [[ ! $ADMIN_ALREADY_UP ]] ; then
+  if ! rebar converge ; then
+    die "Admin node did NOT converge to completion"
+  fi
 fi
 
 add_provider

--- a/workloads/os.map
+++ b/workloads/os.map
@@ -1,0 +1,48 @@
+packet all centos7    centos_7
+packet all ubuntu1404 ubuntu_14_04
+packet all debian7    debian_7
+packet all debian8    debian_8
+
+google all centos7    projects/centos-cloud/global/images/centos-7-v20151104
+google all ubuntu1404 projects/ubuntu-os-cloud/global/images/ubuntu-1404-ubuntu1404-v20151113
+google all ubuntu1504 projects/ubuntu-os-cloud/global/images/ubuntu-1504-ubuntu1504-v20151120
+google all debian7    projects/debian-cloud/global/images/debian-7-wheezy-v20151104
+google all debian8    projects/debian-cloud/global/images/debian-8-jessie-v20151104
+
+#
+# These are hvm-only try switching to default type of t2
+#
+aws us-east-1      centos7 ami-61bbf104
+aws us-west-2      centos7 ami-d440a6e7
+aws us-west-1      centos7 ami-f77fbeb3
+aws eu-central-1   centos7 ami-e68f82fb
+aws eu-west-1      centos7 ami-33734044
+aws ap-southeast-1 centos7 ami-2a7b6b78
+aws ap-southeast-2 centos7 ami-d38dc6e9
+aws ap-northeast-1 centos7 ami-b80b6db8
+aws ap-northeast-2 centos7 ami-dd9d53b3
+aws sa-east-1      centos7 ami-fd0197e0
+
+aws ap-northeast-1 ubuntu1404 ami-20b98c4e
+aws ap-southeast-1 ubuntu1404 ami-06834165
+aws eu-central-1   ubuntu1404 ami-ffaab693
+aws eu-west-1      ubuntu1404 ami-a11dbfd2
+aws sa-east-1      ubuntu1404 ami-08bd3a64
+aws us-east-1      ubuntu1404 ami-0021766a
+aws us-west-1      ubuntu1404 ami-56f59e36
+aws cn-north-1     ubuntu1404 ami-3378b15e
+aws us-gov-west-1  ubuntu1404 ami-d6bbd9f5
+aws ap-southeast-2 ubuntu1404 ami-7bbee518
+aws us-west-2      ubuntu1404 ami-c94856a8
+
+aws ap-northeast-1 ubuntu1504 ami-b43300da
+aws ap-southeast-1 ubuntu1504 ami-e1e32e82
+aws eu-central-1   ubuntu1504 ami-836876ef
+aws eu-west-1      ubuntu1504 ami-8cfe57ff
+aws sa-east-1      ubuntu1504 ami-7578fe19
+aws us-east-1      ubuntu1504 ami-9e2977f4
+aws us-west-1      ubuntu1504 ami-8f7005ef
+aws cn-north-1     ubuntu1504 ami-fd79b090
+aws ap-southeast-2 ubuntu1504 ami-0fa6fc6c
+aws us-west-2      ubuntu1504 ami-b8a0b8d9
+

--- a/workloads/test_os_lookup.sh
+++ b/workloads/test_os_lookup.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+start_args="$@"
+
+. workloads/wl-init.sh
+
+#
+# Kubernetes Config options
+#
+help_options["--deployment-name=<String>"]="Deployment name to hold all the nodes"
+help_options["--teardown"]="Turn down deployment"
+help_options["--keep-admin"]="Keeps admin node running (modifies teardown)"
+help_options["--dns-domain"]="Domain name to append to node names: neode.local"
+
+help_options["--kubernetes-master-count=<Number>"]="Number of masters to start"
+help_options["--kubernetes-node-count=<Number>"]="Number of nodes to start"
+help_options["--kubernetes-gateway-count=<Number>"]="Number of gateway nodes to start (opencontrail only)"
+
+help_options["--kubernetes-source-type=<packageManager|localBuild>"]="Where to get kubernetes from"
+help_options["--kubernetes-cluster-name=<String>"]="Name of cluster: cluster.local"
+help_options["--kubernetes-kube-service-addresses=<CIDRIP>"]="Internal Service IP Addresses"
+
+help_options["--kubernetes-networking=<flannel|opencontrail>"]="Network mode to use"
+help_options["--kubernetes-network-category=<category name>"]="Network category to use for underlay traffic, default: admin"
+
+help_options["--kubernetes-flannel-subnet=<IP>"]="Subnet whole flannel subnet space (dotted quad)"
+help_options["--kubernetes-flannel-prefix=<Number>"]="Subnet prefix for whole flannel subnet space"
+help_options["--kubernetes-flannel-host-prefix=<Number>"]="Subnet prefix for host section flannel subnet space"
+
+help_options["--kubernetes-opencontrail-public-subnet=<CIDRIP>"]="Public network space for opencontrail"
+help_options["--kubernetes-opencontrail-private-subnet=<CIDRIP>"]="Private network space for opencontrail"
+
+help_options["--kubernetes-dns=<true|false>"]="Use DNS add-on"
+help_options["--kubernetes-dns-replicas=<Number>"]="Number of DNS replicas to run"
+help_options["--kubernetes-ui=<true|false>"]="Use Kube-UI"
+help_options["--kubernetes-cluster-logging=<true|false>"]="Use cluster logging"
+help_options["--kubernetes-cluster-monitoring=<true|false>"]="Use cluster monitoring"
+
+help_options["--kubernetes-test=<true|false>"]="Add the test role to validate completion"
+
+
+# Mostly likely will require host - make it the default
+DEFAULT_ACCESS=HOST
+
+# Make sure we have the workload
+WL_KUBERNETES=true
+
+# Turn off provisioner by default
+CON_NO_PROVISIONER=true
+
+KEEP_ADMIN=false
+
+#
+# Process config and validate providers
+#
+. workloads/wl-lib.sh
+
+echo "aws:all:centos7 = $(lookup_image_id "aws" "all" "centos7")"
+echo "aws:fred:centos7 = $(lookup_image_id "aws" "fred" "centos7")"
+echo "aws:us-west-2:centos7 = $(lookup_image_id "aws" "us-west-2" "centos7")"
+echo "packet:fred:centos7 = $(lookup_image_id "packet" "fred" "centos7")"
+echo "google:jkk:centos7 = $(lookup_image_id "google" "jjk" "centos7")"
+
+


### PR DESCRIPTION
standard os name to lookup the right string for that
provider type.  Add a test script.

Also allow for existing admin nodes not have to wait
for convergence.