### PR TITLE
Make provisioner container discover installable oses

### DIFF
--- a/containers/provisioner/entrypoint.d/42-start-services.sh
+++ b/containers/provisioner/entrypoint.d/42-start-services.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Start tftpd
+/usr/sbin/in.tftpd --listen --user root --address 0.0.0.0:69 --secure /tftpboot &
+# Start web server
+/usr/local/bin/sws --listen=:8091 --site=/tftpboot </dev/null 2>&1 1>/var/log/sws.log &

--- a/containers/provisioner/entrypoint.d/45-bind-provisioner-service.sh
+++ b/containers/provisioner/entrypoint.d/45-bind-provisioner-service.sh
@@ -2,4 +2,4 @@
 
 # Add provisioner-service after initial converge.
 rebar nodes bind "system-phantom.internal.local" to "provisioner-service"
-rebar nodes commit "system-phantom.internal.local" || :
+

--- a/containers/provisioner/entrypoint.d/50-find-supported-operating-systems.sh
+++ b/containers/provisioner/entrypoint.d/50-find-supported-operating-systems.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+supported_oses="$(rebar deployments get system attrib provisioner-supported-oses |jq -c '.value')"
+declare -a available_oses
+declare -A install_repos
+iso_dir="/tftpboot/isos"
+rhelish_re='^(redhat|centos|fedora)'
+
+# First, extract ISO files for operating systems we know about.
+for key in $(jq -r 'keys[]' <<< "$supported_oses"); do
+    os_specs="$(jq -r ".[\"$key\"]" <<< "$supported_oses")"
+    iso="$(jq -r ".iso_file" <<< "$os_specs")"
+    os_install_dir="/tftpboot/$key/install"
+    os_web_path="http://${EXTERNAL_IP%%/*}:8091/${key}/install"
+    if [[ ! -f $os_install_dir/.${iso}.rebar_canary ]]; then
+        if ! [[ $iso && -f $iso_dir/$iso ]]; then
+            echo "$iso is not present, skipping"
+            continue
+        fi
+        echo "Extracting $iso for $key"
+        [[ -d "${os_install_dir}.extracting" ]] && rm -rf "${os_install_dir}.extracting"
+        mkdir -p "${os_install_dir}.extracting"
+        if [[ $key = esxi* ]]; then
+            # ESXi needs some special love extracting the files from the image.
+            # Note that this is likely to fail inside the container.
+            tmpdir="$(mktemp -d "/tmp/esx-XXXXXXXX")"
+            mount -o loop "$iso_dir/$iso" "$tmpdir"
+            rsync -av "$tmpdir" "${os_install_dir}.extracting"
+            sync
+            umount "$tmpdir"
+            rm -rf "$tmpdir"
+            chmod +w "${os_install_dir}.extracting"/*
+            sed -e "s:/::g" -e "3s:^:prefix=/../${key}/install/\\n:" -i.bak "${os_install_dir}.extracting"/boot.cfg
+        else
+            # Everything else just needs bsdtar
+            (cd "${os_install_dir}.extracting"; bsdtar -x -f "${iso_dir}/${iso}")
+        fi
+        if [[ $key =~ $rhelish_re ]]; then
+            # Rewrite local package metadata
+            (
+                cd "${os_install_dir}.extracting"
+                groups=($(echo repodata/*comps*.xml))
+                createrepo -g "${groups[-1]}" .
+            )
+        fi
+        touch "${os_install_dir}.extracting/.${iso}.rebar_canary"
+        [[ -d "${os_install_dir}" ]] && rm -rf "${os_install_dir}"
+        mv "${os_install_dir}.extracting" "${os_install_dir}"
+    else
+        echo "$iso already extracted for $key"
+    fi
+    available_oses+=("$key")
+    case $key in
+        ubuntu*)
+            if [[ -d $os_install_dir/dists/stable ]]; then
+                install_repos["$key"]="[\"deb $os_web_path stable main restricted\"]"
+            fi;;
+        suse*)
+            install_repos["$key"]="[\"bare $os_web_path\"]";;
+        redhat*|centos*|fedora*)
+            if [[ -d $os_install_dir/repodata ]]; then
+               install_repos["$key"]="[\"bare $os_web_path\"]"
+            elif [[ -d $os_install_dir/Server/repodata ]]; then
+                install_repos["$key"]="[\"bare $os_web_path/Server\"]"
+            fi;;
+    esac
+done
+
+if [[ $available_oses ]]; then
+    avail_os_line="$(printf '"%s":true,' "${available_oses[@]}")"
+    avail_os_line="{\"value\": { ${avail_os_line%,} }}"
+else
+    avail_os_line='{"value": {} }'
+fi
+
+if [[ ${#install_repos[@]} != 0 ]]; then
+    install_repo_line='{"value": {'
+    for key in "${!install_repos[@]}"; do
+        install_repo_line+="\"$key\": {\"provisioner\": ${install_repos[$key]} },"
+    done
+    install_repo_line="${install_repo_line%,} }}"
+else
+    install_repo_line='{"value": {} }'
+fi
+
+if which selinuxenabled && selinuxenabled; then
+    restorecon -R -F /tftpboot
+fi
+
+rebar deployments set system attrib provisioner-available-oses to "$avail_os_line"
+rebar deployments set system attrib provisioner-provided-repos to "$install_repo_line"
+

--- a/containers/provisioner/entrypoint.d/60-bind-services.sh
+++ b/containers/provisioner/entrypoint.d/60-bind-services.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-if ! rebar nodes roles "$HOSTNAME" |grep -q 'provisioner-base-images'; then
+if ! rebar nodes roles "$HOSTNAME" |grep -q 'provisioner-database'; then
      rebar nodes bind "$HOSTNAME" to 'provisioner-database'
-     rebar nodes bind "$HOSTNAME" to 'provisioner-base-images'
 fi

--- a/containers/provisioner/entrypoint.d/80-register-consul-services.sh
+++ b/containers/provisioner/entrypoint.d/80-register-consul-services.sh
@@ -8,8 +8,4 @@ else
     sed -e "s/FILLMEIN/${EXTERNAL_IP%%/*}/" root/external-tftp-service.json >/etc/consul.d/tftp.json
 fi
 consul reload
-
-# Start tftpd
-/usr/sbin/in.tftpd --listen --user root --address 0.0.0.0:69 --secure /tftpboot &
-# Start web server
-/usr/local/bin/sws --listen=:$PROV_WEBPORT --site=$PROV_TFTPROOT </dev/null 2>&1 1>/var/log/sws.log &
+rebar deployments commit system

--- a/containers/provisioner/start-up.sh
+++ b/containers/provisioner/start-up.sh
@@ -22,6 +22,9 @@ netname_re='"network":"([^ ]+)"'
 # install key first
 export REBAR_KEY="$(get_param "$install_key_re")"
 export REBAR_ENDPOINT="$(get_param "$rebar_re")"
+
+echo "export REBAR_KEY=\"$REBAR_KEY\"" >/etc/profile.d/rebar-key.sh
+echo "export REBAR_ENDPOINT=\"$REBAR_ENDPOINT\"" >> /etc/profile.d/rebar-key.sh
 # Provisioner and Rebar web endpoints next
 
 # Download the Rebar CLI


### PR DESCRIPTION
This shifts responsibility for discovering installable operating systems
from the provisioner-base-images role into one of the startup scripts
for the provisioner container.