### PR TITLE
Make rebar_api startup a bit smarter.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ install-*.log
 
 # Dynamically built by init_files.sh
 /compose/access.env
+/compose/services.env
 /compose/docker-compose.yml
 
 .idea

--- a/compose/docker-compose-common.yml
+++ b/compose/docker-compose-common.yml
@@ -50,6 +50,7 @@ rebar_api:
   env_file:
     - ./common.env
     - ./access.env
+    - ./services.env
 
 ntp:
   image: digitalrebar/dr_ntp

--- a/compose/init_files.sh
+++ b/compose/init_files.sh
@@ -4,6 +4,8 @@ if which sudo 2>/dev/null >/dev/null ; then
     SUDO=sudo
 fi
 
+SERVICES="proxy-service network-server rebar-api_service chef-service ntp-service dns-service logging-service dns-mgmt_service"
+
 function usage {
     echo "Usage: $0 <flags> [options docker-compose flags/commands]"
     echo "  -h or --help - help (this)"
@@ -40,7 +42,7 @@ while [[ $1 == -* ]] ; do
       exit 0
       ;;
     --clean)
-        rm -f access.env dc docker-compose.yml config-dir/api/config/networks/the_admin.json config-dir/api/config/networks/the_bmc.json
+        rm -f access.env services.env dc docker-compose.yml config-dir/api/config/networks/the_admin.json config-dir/api/config/networks/the_bmc.json
         $SUDO rm -rf data-dir
       exit 0
       ;;
@@ -59,6 +61,7 @@ while [[ $1 == -* ]] ; do
     --provisioner)
       FILES="$FILES provisioner.yml"
       PROVISION_IT="YES"
+      SERVICES+=" dhcp-mgmt_service dhcp-service provisioner-service"
       ;;
     --debug)
       FILES="$FILES debug.yml"
@@ -149,6 +152,10 @@ EXTERNAL_IP=$EXTERNAL_IP
 FORWARDER_IP=$FORWARDER_IP
 CONSUL_JOIN=$CONSUL_JOIN
 DR_START_TIME=$(date +%s)
+EOF
+
+cat >services.env <<EOF
+SERVICES=$SERVICES
 EOF
 
 cat >config-dir/consul/server-advertise.json <<EOF

--- a/containers/rebar-api/entrypoint.d/26-build-config-file.sh
+++ b/containers/rebar-api/entrypoint.d/26-build-config-file.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+if ! kv_get digitalrebar/private/api/keys/rebar_key &>/dev/null; then
+    cd /opt/digitalrebar/core
+    export BUILT_CFG_FILE=/tmp/final.json
+
+    # This is a hack as well for now.
+    cat > config/filters/admin-default.json <<EOF
+{ 
+  "name": "default",
+  "priority": 50,
+  "template": "{{node.name}}.$BASE_DOMAINNAME",
+  "matcher": "net.category == \"admin\"",
+  "service": "system"
+}
+EOF
+    cp /home/rebar/.ssh/id_rsa.pub config/ssh_keys/admin-0.key
+
+    ./rebar-build-json.rb > ${BUILT_CFG_FILE}
+fi

--- a/containers/rebar-api/entrypoint.d/27-bind-rebar_api-service.sh
+++ b/containers/rebar-api/entrypoint.d/27-bind-rebar_api-service.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [[ -f $BUILT_CFG_FILE ]]; then
+    # Add keys into the system
+    bind_service rebar-api_service
+    rebar deployments bind system to rebar-access || :
+    keys=`jq -r .ssh_keys ${BUILT_CFG_FILE}`
+    set_service_attrib rebar-access rebar-access_keys "{ \"value\": $keys }"
+    set_service_attrib rebar-access rebar-machine_key "{ \"value\": \"`cat /etc/rebar.install.key`\" }"
+fi

--- a/containers/rebar-api/entrypoint.d/32-wait-for-services.sh
+++ b/containers/rebar-api/entrypoint.d/32-wait-for-services.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+all_services_present=false
+role_ids=()
+depl_id="$(rebar deployments show $SERVICE_DEPLOYMENT |jq '.id')"
+for svc in $SERVICES; do
+    role_ids+=($(rebar roles show "$svc" |jq '.id') )
+done
+
+while [[ $all_services_present != true ]]; do
+    all_services_present=true
+    for svc_id in "${role_ids[@]}"; do
+        dr_id=$(rebar deploymentroles match "{\"role_id\": $svc_id, \"deployment_id\": $depl_id}" |jq '.[0].id')
+        if [[ ! $dr_id || $dr_id = null ]]; then
+            all_services_present=false
+            sleep 1
+            break
+        fi
+    done
+done


### PR DESCRIPTION
This patch updates init_files.sh to pass a list of services that
rebar_api should wait to be bound in the system deployment before
letting the annealer run.  It also rearranges the startup scrupt
ordering to ensure that we only run initial bootstrap tasks after all
the services we require are present and accouted for.