### PR TITLE
Make sure any keys that disable root login are removed from host

### DIFF
--- a/run-in-google.sh
+++ b/run-in-google.sh
@@ -60,7 +60,7 @@ ENV_VAR="\"google\": true,"
 export ADMIN_IP="$IP/$CIDR"
 
 # Make sure our key is in place.
-gcloud compute ssh $ZONE_NAME ubuntu@$DEVICE_ID --ssh-key-file $HOME/.ssh/id_rsa --command "sudo sed -i -e '1d' /root/.ssh/authorized_keys"
+gcloud compute ssh $ZONE_NAME ubuntu@$DEVICE_ID --ssh-key-file $HOME/.ssh/id_rsa --command "sudo sed -i -e '/login as the user/d' /root/.ssh/authorized_keys"
 gcloud compute ssh $ZONE_NAME root@$DEVICE_ID --ssh-key-file $HOME/.ssh/id_rsa --command "date"
 gcloud compute ssh $ZONE_NAME ubuntu@$DEVICE_ID --ssh-key-file $HOME/.ssh/id_rsa --command "sudo sed -i -e '1d' /root/.ssh/authorized_keys"
 


### PR DESCRIPTION
I don't know whether this is unique to my GCE environment, but whenever I create a new VM, I get a load of keys put into /root/authorized_keys relating to the SSH keys set up on my GCE project.  A lot of these are configured to not allow root login - the key begins with 

"no-port-forwarding,no-agent-forwarding,no-X11-forwarding,command="echo 'Please login as the user \"ubuntu\" rather than the user \"root\".';echo;sleep 10" ssh-rsa AAAA....."

Because the key being used by Rebar is one of these, rebar fails as it gets unexpected output to its commands.

This PR, which works for me, removes any lines in the authorized_keys file which have this command.  The deploy scripts still add the appropriate key manually, so deleting these keys doesn't seem to cause a problem.

TBH - I don't know whether this is "safe" for all users, so wouldn't be surprised if you don't want to accept the change!