### PR TITLE
Updating Python step can be very slow, so warn users

### DIFF
--- a/tasks/base-ubuntu1404.yml
+++ b/tasks/base-ubuntu1404.yml
@@ -4,7 +4,7 @@
     sudo: yes
   - name: Update repos (was not working from apt:)
     command: sudo apt-get update -y
-  - name: Update python.
+  - name: Update python [SLOW]
     command: sudo apt-get upgrade -y
   - name: Install Prereqs [SLOW]
     apt: name={{ item }} state=latest


### PR DESCRIPTION
I've found the "Update Python" step can take a long time on a newly provisioned master (I guess because its actually doing a full apt-get upgrade of everything?).  Maybe a complete fix is to _just_ update Python, but in the meantime a warning that this step can be slow would be helpful.