### PR TITLE
OpenStack Provider Interface (based on DreamHost) 

### DIFF
--- a/containers/cloudwrap/Dockerfile
+++ b/containers/cloudwrap/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get -y update && \
     apt-add-repository ppa:brightbox/ruby-ng && \
     add-apt-repository "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-backports main restricted universe multiverse" && \
     apt-get -y update && \
-    apt-get -y install ruby2.2 ruby2.2-dev make cmake curl build-essential jq libxml2-dev libcurl4-openssl-dev libssl-dev && \
+    apt-get -y install ruby2.2 ruby2.2-dev make cmake curl build-essential jq libxml2-dev libcurl4-openssl-dev libssl-dev python-openstackclient && \
     gem install bundler && \
     mkdir -p /var/cache/cloudwrap/gems
 

--- a/containers/cloudwrap/cloudwrap/api.rb
+++ b/containers/cloudwrap/cloudwrap/api.rb
@@ -33,6 +33,8 @@ class Servers
       fixed_args[:key_name]=kp_name
     when 'Google'
       fixed_args[:public_key_path] = "#{kp_loc}.pub"
+    when 'OpenStack'
+      log("PLACE HOLDER")
     when 'Packet'
       # Packet endpoint has the account key
       packet_project_token = endpoint['project_token']
@@ -147,6 +149,8 @@ class Servers
         log("Will create new srver with #{fixed_args.inspect}")
         server = ep.servers.create(fixed_args)
         log("Created server #{server.to_json}")
+      when 'OpenStack'
+        log("PLACE HOLDER")
       when 'Packet'
         # Packet endpoint has the account key
         packet_project_token = endpoint['project_token']
@@ -211,6 +215,8 @@ class Servers
         ep = get_endpoint(endpoint)
         return [] unless ep
         ep.servers if ep
+      when 'OpenStack'
+        log("PLACE HOLDER")
       when 'Packet'
         # Packet endpoint has the account key
         packet_project_token = endpoint['project_token']
@@ -239,6 +245,8 @@ class Servers
     when 'AWS', 'Google'
       ep = get_endpoint(endpoint)
       ep.servers.get(id)
+    when 'OpenStack'
+      log("PLACE HOLDER")
     when 'Packet'
       # Packet endpoint has the account key
       packet_project_token = endpoint['project_token']
@@ -268,6 +276,8 @@ class Servers
     case endpoint["provider"]
     when 'AWS', 'Google'
       get(endpoint,id).reboot
+    when 'OpenStack'
+      log("PLACE HOLDER")
     when 'Packet'
       # Packet endpoint has the account key
       packet_project_token = endpoint['project_token']
@@ -303,6 +313,8 @@ class Servers
         server = ep.servers.get(id) if ep
         log("Could not find server for: #{id}") unless server
         server.destroy if server
+      when 'OpenStack'
+        log("PLACE HOLDER")
       when 'Packet'
         # Packet endpoint has the account key
         packet_project_token = endpoint['project_token']
@@ -359,6 +371,8 @@ class Servers
         log "ICMP access already enabled"
       end
     when 'Google' then true
+    when 'OpenStack'
+      log("PLACE HOLDER")
     when 'Packet' then true
     else
       raise "No idea how to handle #{endpoint["provider"]}"

--- a/containers/cloudwrap/cloudwrap/api.rb
+++ b/containers/cloudwrap/cloudwrap/api.rb
@@ -37,7 +37,7 @@ class Servers
     when 'Google'
       fixed_args[:public_key_path] = "#{kp_loc}.pub"
     when 'OpenStack'
-      openstack_addkey(endpoint, kp_name, "#{kp_loc}.pub")
+      OpenStack::addkey(endpoint, kp_name, "#{kp_loc}.pub")
     when 'Packet'
       # Packet endpoint has the account key
       packet_project_token = endpoint['project_token']
@@ -154,7 +154,7 @@ class Servers
         log("Created server #{server.to_json}")
       when 'OpenStack'
         name = (fixed_args[:hostname] ? fixed_args[:hostname] : "rebar-cloudwrap-#{node_id}").split('.')[0]
-        openstack_create(endpoint, name)
+        OpenStack::create(endpoint, name)
       when 'Packet'
         # Packet endpoint has the account key
         packet_project_token = endpoint['project_token']
@@ -220,7 +220,7 @@ class Servers
         return [] unless ep
         ep.servers if ep
       when 'OpenStack'
-        openstack_list(endpoint)
+        OpenStack::list(endpoint)
       when 'Packet'
         # Packet endpoint has the account key
         packet_project_token = endpoint['project_token']
@@ -250,7 +250,7 @@ class Servers
       ep = get_endpoint(endpoint)
       ep.servers.get(id)
     when 'OpenStack'
-      openstack_get(endpoint, id)
+      OpenStack::get(endpoint, id)
     when 'Packet'
       # Packet endpoint has the account key
       packet_project_token = endpoint['project_token']
@@ -281,7 +281,7 @@ class Servers
     when 'AWS', 'Google'
       get(endpoint,id).reboot
     when 'OpenStack'
-      openstack_reboot(endpoint,id)
+      OpenStack::reboot(endpoint,id)
     when 'Packet'
       # Packet endpoint has the account key
       packet_project_token = endpoint['project_token']
@@ -318,7 +318,7 @@ class Servers
         log("Could not find server for: #{id}") unless server
         server.destroy if server
       when 'OpenStack'
-        openstack_delete(endpoint, id)
+        OpenStack::delete endpoint, id
       when 'Packet'
         # Packet endpoint has the account key
         packet_project_token = endpoint['project_token']

--- a/containers/cloudwrap/cloudwrap/api.rb
+++ b/containers/cloudwrap/cloudwrap/api.rb
@@ -155,6 +155,7 @@ class Servers
       when 'OpenStack'
         name = (fixed_args[:hostname] ? fixed_args[:hostname] : "rebar-cloudwrap-#{node_id}").split('.')[0]
         server = OpenStack::create(endpoint, name, keyfile_name(node_id), fixed_args[:image_id], fixed_args[:flavor_id])
+        log("Created server #{server.to_json}")        
       when 'Packet'
         # Packet endpoint has the account key
         packet_project_token = endpoint['project_token']
@@ -198,6 +199,9 @@ class Servers
       when 'Google'
         Diplomat::Kv.put("cloudwrap/create/#{node_id}/#{server.name}",endpoint.to_json)
         ret = {id: server.name}
+      when 'OpenStack'
+        Diplomat::Kv.put("cloudwrap/create/#{node_id}/#{server['id']}",endpoint.to_json)
+        ret = server
       when 'Packet'
         Diplomat::Kv.put("cloudwrap/create/#{node_id}/#{server['id']}",endpoint.to_json)
         ret = server

--- a/containers/cloudwrap/cloudwrap/api.rb
+++ b/containers/cloudwrap/cloudwrap/api.rb
@@ -154,7 +154,7 @@ class Servers
         log("Created server #{server.to_json}")
       when 'OpenStack'
         name = (fixed_args[:hostname] ? fixed_args[:hostname] : "rebar-cloudwrap-#{node_id}").split('.')[0]
-        OpenStack::create(endpoint, name)
+        server = OpenStack::create(endpoint, name, keyfile_name(node_id), fixed_args[:image_id], fixed_args[:flavor_id])
       when 'Packet'
         # Packet endpoint has the account key
         packet_project_token = endpoint['project_token']

--- a/containers/cloudwrap/cloudwrap/common.rb
+++ b/containers/cloudwrap/cloudwrap/common.rb
@@ -1,3 +1,7 @@
+#!/usr/bin/env ruby
+# Copyright 2016, RackN Inc
+
+
 def log(line)
   STDOUT.puts(line)
   STDOUT.flush
@@ -216,6 +220,8 @@ def get_endpoint(ep)
     res = fix_hash(ep)
     res[:google_json_key_string] = JSON.generate(res.delete(:google_json_key))
     Fog::Compute.new(res)
+  when 'OpenStack'
+    log("Placeholder")
   when 'Packet' then nil
   else
     log("Cannot get endpoint for #{ep['provider']}")

--- a/containers/cloudwrap/cloudwrap/common.rb
+++ b/containers/cloudwrap/cloudwrap/common.rb
@@ -220,8 +220,7 @@ def get_endpoint(ep)
     res = fix_hash(ep)
     res[:google_json_key_string] = JSON.generate(res.delete(:google_json_key))
     Fog::Compute.new(res)
-  when 'OpenStack'
-    log("Placeholder")
+  when 'OpenStack' then nil
   when 'Packet' then nil
   else
     log("Cannot get endpoint for #{ep['provider']}")

--- a/containers/cloudwrap/cloudwrap/openstack.rb
+++ b/containers/cloudwrap/cloudwrap/openstack.rb
@@ -18,7 +18,6 @@ module OpenStack
     image_id = find_image(images, image)
     flavors = flavors(endpoint)
     flavor_id = find_flavor(flavors, flavor)
-    keyname = "foo"
     params = "--key-name \'#{keyname}\' " \
              "--image \'#{image_id}\' " \
              "--flavor \'#{flavor_id}\' " \
@@ -32,7 +31,7 @@ module OpenStack
   # upload key
   def self.addkey(endpoint, name, key)
     log "OpenStack adding key #{key}"
-    base endpoint, "keypair create \'#{name}\' \'#{key}\'"
+    base endpoint, "keypair create --public-key \'#{key}\' \'#{name}\'"
   end
 
   # remove key
@@ -136,8 +135,8 @@ module OpenStack
   # provide the base CLI interface with correct flags
   def self.base(endpoint, cmd, with_result=nil)
 
-    log("OpenStack inputs #{endpoint}")
-    cmd = "openstack --os-username \'#{endpoint['os-username']}\' " \
+    #log("OpenStack inputs #{endpoint}")
+    full_cmd = "openstack --os-username \'#{endpoint['os-username']}\' " \
                     "--os-password \'#{endpoint['os-password']}\' " \
                     "--os-project-name \'#{endpoint['os-project-name']}\' " \
                     "--os-region-name \'#{endpoint['os-region-name']}\' " \
@@ -146,11 +145,12 @@ module OpenStack
 
     o = nil
     if with_result
-      o = %x[#{cmd} #{with_result}] rescue nil
+      o = %x[#{full_cmd} #{with_result}] rescue nil
+      log "executed OpenStack command [#{cmd} #{with_result}] with result #{o}"
     else
-      o = system(cmd) rescue false
+      o = system(full_cmd) rescue false
+      log "system call OpenStack command [#{cmd}] with result #{o}"
     end
-    log "executed OpenStack command #{cmd}"
 
     return o
 

--- a/containers/cloudwrap/cloudwrap/openstack.rb
+++ b/containers/cloudwrap/cloudwrap/openstack.rb
@@ -10,119 +10,218 @@
 #   os-region-name: ''
 # }
 
-require './common'
+module OpenStack
 
-# create server
-def openstack_create(endpoint, name)
+  # create server
+  def self.create(endpoint, name, keyname, image="CentOS", flavor="2048")
+    images = images(endpoint)
+    image_id = find_image(images, image)
+    flavors = flavors(endpoint)
+    flavor_id = find_flavor(flavors, flavor)
+    keyname = "foo"
+    params = "--key-name \'#{keyname}\' " \
+             "--image \'#{image_id}\' " \
+             "--flavor \'#{flavor_id}\' " \
+             "\'#{name}\'"
+    raw = base endpoint, "server create #{params}", "-f shell"
+    o = unshell(raw)
+    id = o["id"]
+    return o rescue nil
+  end
 
-openstack server create [-h] [-f {shell,table}] [-c COLUMN]
-                               [--variable VARIABLE] [--prefix PREFIX] --image
-                               <image> --flavor <flavor>
-                               [--security-group <security-group-name>]
-                               [--key-name <key-name>]
-                               [--property <key=value>]
-                               [--file <dest-filename=source-filename>]
-                               [--user-data <user-data>]
-                               [--availability-zone <zone-name>]
-                               [--block-device-mapping <dev-name=mapping>]
-                               [--nic <nic-config-string>]
-                               [--hint <key=value>]
-                               <server-name>
+  # upload key
+  def self.addkey(endpoint, name, key)
+    log "OpenStack adding key #{key}"
+    base endpoint, "keypair create \'#{name}\' \'#{key}\'"
+  end
 
-  image = "CentOS-7"
-  flavor = "gp1.semisonic"
-  keyname = "foo"
-  base(endpoint, "server create --key-name #{keyname}--image #{image} --flavor #{favor} #{id} -f shell")
-end
+  # remove key
+  def self.deletekey(endpoint, name)
+    log "OpenStack removed key #{key}"
+    base endpoint, "keypair delete \'#{name}\'"
+  end
 
-# upload key
-def openstack_addkey(endpoint, name, key)
-  base(endpoint, "keypair create #{name} #{key}")
-end
+  # delete provided server
+  def self.delete(endpoint, id)
+    log "OpenStack deleting #{id}"
+    base endpoint, "server delete \'#{id}\'"
+  end
 
-# remove key
-def openstack_deletekey(endpoint, name)
-  base(endpoint, "keypair delete #{name}")
-end
+  # reboot provided server
+  def self.reboot(endpoint, id)
+    base endpoint, "server reboot --hard \'#{id}\'"
+  end
 
-# delete provided server
-def openstack_delete(endpoint, id)
-  base(endpoint, "server delete \'#{id}\'")
-end
+  # get list of servers
+  def self.list(endpoint)
+    raw = base(endpoint, "server list", "-f csv")
+    o = uncsv raw
+    log("openstack.list found #{o.count} servers")
+    return o
+  end
 
-# reboot provided server
-def openstack_reboot(endpoint, id)
-  base(endpoint, "server reboot --hard \'#{id}\'")
-end
+  # find GUID of server from name
+  def self.find_id(endpoint, name)
+    servers = list endpoint
+    servers.each do |k, v|
+      return k if v == name
+    end
+    return nil
+  end
 
-# get list of servers
-def openstack_list(endpoint)
-  base(endpoint, "server list -f csv")
-end
+  # get server details
+  def self.get(endpoint, id)
+    raw = base(endpoint, "server show \'#{id}\'", "-f shell")
+    o = unshell raw
+    log("openstack.get #{o["name"]} is #{o["id"]}")
+    return o
 
-# get server details
-def openstack_get(endpoint, id)
-  base(endpoint, "server show \'#{id}\' -f csv")
+    # os-dcf:diskconfig="AUTO"
+    # os-ext-az:availability_zone="iad-2"
+    # os-ext-sts:power_state="1"
+    # os-ext-sts:task_state="None"
+    # os-ext-sts:vm_state="active"
+    # os-srv-usg:launched_at="2016-03-18T04:36:07.000000"
+    # os-srv-usg:terminated_at="None"
+    # accessipv4=""
+    # accessipv6=""
+    # addresses="public=208.113.135.196, 2607:f298:5:101d:f816:3eff:fe25:d05"
+    # config_drive="True"
+    # created="2016-03-18T04:35:57Z"
+    # flavor="gp1.semisonic (50)"
+    # hostid="2a74b475939b7e5956a2334e4ce2f5675340e0976778b53742aaec99"
+    # id="9d5e5a03-5820-48e3-9bdf-f5ac18af4c64"
+    # image="CentOS-7 (c1e8c5b5-bea6-45e9-8202-b8e769b661a4)"
+    # key_name="rack1"
+    # name="delete2"
+    # os-extended-volumes:volumes_attached="[]"
+    # progress="0"
+    # properties=""
+    # security_groups="[{u'name': u'default'}]"
+    # status="ACTIVE"
+    # tenant_id="ac8fccd077d04729b4cb5f85506bb336"
+    # updated="2016-03-18T04:36:07Z"
+    # user_id="b55909ea28574f479dc9cf5a9b673697"
 
-    os-dcf:diskconfig="AUTO"
-    os-ext-az:availability_zone="iad-2"
-    os-ext-sts:power_state="1"
-    os-ext-sts:task_state="None"
-    os-ext-sts:vm_state="active"
-    os-srv-usg:launched_at="2016-03-18T04:36:07.000000"
-    os-srv-usg:terminated_at="None"
-    accessipv4=""
-    accessipv6=""
-    addresses="public=208.113.135.196, 2607:f298:5:101d:f816:3eff:fe25:d05"
-    config_drive="True"
-    created="2016-03-18T04:35:57Z"
-    flavor="gp1.semisonic (50)"
-    hostid="2a74b475939b7e5956a2334e4ce2f5675340e0976778b53742aaec99"
-    id="9d5e5a03-5820-48e3-9bdf-f5ac18af4c64"
-    image="CentOS-7 (c1e8c5b5-bea6-45e9-8202-b8e769b661a4)"
-    key_name="rack1"
-    name="delete2"
-    os-extended-volumes:volumes_attached="[]"
-    progress="0"
-    properties=""
-    security_groups="[{u'name': u'default'}]"
-    status="ACTIVE"
-    tenant_id="ac8fccd077d04729b4cb5f85506bb336"
-    updated="2016-03-18T04:36:07Z"
-    user_id="b55909ea28574f479dc9cf5a9b673697"
+  end
 
-end
+  private
 
-private
+  # find a flavor matching the requested type
+  def self.find_flavor(endpoint, match)
+    favors(endpoint).keys.first rescue []
+  end
 
-# find a flavor matching the requested type
-def find_flavor(endpoint, match)
-  favor(endpoint)[0]
-end
+  # find an image matching the requested type
+  def self.find_image(endpoint, match)
+    images(endpoint).keys.first rescue []
+  end
 
-# find an image matching the requested type
-def find_image(endpoint, match)
-  images(endpoint)[0]
-end
+  # retrieve the flavors
+  def self.flavors(endpoint)
+    raw = base(endpoint, "openstack flavors list", "-f csv")
 
-# retrieve the flavors
-def flavors(endpoint)
-  base(endpoint, "openstack flavors list -f csv")
-end
+    o = []
+    return o
 
-# retrieve the images
-def images(endpoint)
-  base(endpoint, "openstack images list -f csv")
-end
+  end
 
-# provide the base CLI interface with correct flags
-def base(endpoint, cmd)
+  # retrieve the images
+  def self.images(endpoint)
+    raw = base(endpoint, "openstack images list", "-f csv")
+    o = []
+    return o
+  end
 
-  cmd = "openstack --os-username \'#{endpoint['os-username']}\' " \
-                  "--os-password \'#{endpoint['os-password']}\' " \
-                  "--os-project-name \'#{endpoint['os-project-name']}\' " \
-                  "--os-region-name \'#{endpoint['os-region-name']}\' " \
-                  "--os-auth-url \'#{endpoint['os-auth-url']}\' " \
-                  "#{cmd}"
+  # provide the base CLI interface with correct flags
+  def self.base(endpoint, cmd, with_result=nil)
+
+    log("OpenStack inputs #{endpoint}")
+    cmd = "openstack --os-username \'#{endpoint['os-username']}\' " \
+                    "--os-password \'#{endpoint['os-password']}\' " \
+                    "--os-project-name \'#{endpoint['os-project-name']}\' " \
+                    "--os-region-name \'#{endpoint['os-region-name']}\' " \
+                    "--os-auth-url \'#{endpoint['os-auth-url']}\' " \
+                    "#{cmd}"
+
+    o = nil
+    if with_result
+      o = %x[#{cmd} #{with_result}] rescue nil
+    else
+      o = system(cmd) rescue false
+    end
+    log "executed OpenStack command #{cmd}"
+
+    return o
+
+  end
+
+  def self.public_v4(raw)
+    if raw =~ /public=([0-9.]),/
+      return $0
+    else
+      raw
+    end
+  end
+
+  # parse raw shell output
+  def self.unshell(raw)
+
+    o = {}
+    raw.each do |line|
+      l = line.split('=')
+      o[l[0]] = l[1]
+    end
+    return o
+  end
+
+  # parse raw cvs voutput
+  def self.uncsv(raw, key)
+
+    header = raw[0].split(",")
+    raw.delete[0]
+    o = {}
+    raw.each do |line|
+      l = line.split(",")
+      oo = {}
+      header.each_index do |i,value|
+        oo[value] = l[i]
+      end
+      o[oo[key]] = oo
+    end
+    return o
+
+  end
+
+  #   "ID","Name"
+  # "149ae890-a138-4a35-9ad1-d9c31aa3750c","CoreOS"
+  def self.match_image(images, request)
+    images.each do |k, v|
+      return k if v =~ request
+    end
+    # backup to CentOS
+    images.each do |k, v|
+      return k if v =~ /CentOS/
+    end
+    # if all else fails, return first image
+    return images.keys.first
+  end
+
+  # "ID","Name","RAM","Disk","Ephemeral","Swap","VCPUs","RXTX Factor","Is Public","Extra Specs"
+  # "100","gp1.subsonic",1024,80,0,"",1,1.0,True,""
+  def self.match_flavor(flavors, request)
+    # exact match, easy!
+    return request if flavors[request]
+
+    # try to match RAM
+    flavors.each do |k, values|
+      return k if values["RAM"] == request
+    end
+
+    # assume % input, pick matching item
+    percent = ((request.to_i/100)*flavors.length).to_i
+    return favors.keys[percent] rescue flavors.keys.first
+
+  end
 
 end

--- a/containers/cloudwrap/cloudwrap/openstack.rb
+++ b/containers/cloudwrap/cloudwrap/openstack.rb
@@ -14,7 +14,6 @@ module OpenStack
 
   # create server
   def self.create(endpoint, name, keyname, image, flavor)
-    endpoint["debug"] = true
     images = images(endpoint)
     image_id = match_image(images, image || "CentOS")
     flavors = flavors(endpoint)

--- a/containers/cloudwrap/cloudwrap/openstack.rb
+++ b/containers/cloudwrap/cloudwrap/openstack.rb
@@ -161,7 +161,7 @@ module OpenStack
 
   # use Status "addresses"
   def self.public_v4(raw)
-    o= if raw =~ /public=([0-9.]*),/
+    o= if raw =~ /public:([0-9.]*),/
       $1
     else
       raw
@@ -175,7 +175,8 @@ module OpenStack
 
     o = {}
     raw.each do |line|
-      l = line.split('=')
+      # public is a hack because of multiple uses of EQUAL in OpenStack return
+      l = line.gsub("public=","public:").split('=')
       o[l[0]] = l[1].gsub!(/\A"|"\Z/, '')
     end
     return o

--- a/containers/cloudwrap/cloudwrap/openstack.rb
+++ b/containers/cloudwrap/cloudwrap/openstack.rb
@@ -1,0 +1,128 @@
+#!/usr/bin/env ruby
+# Copyright 2016, RackN Inc
+
+# endpoint for OpenStack
+# {
+#   os-username: '',
+#   os-password: '',
+#   os-project-name: '',
+#   os-auth-url: '',
+#   os-region-name: ''
+# }
+
+require './common'
+
+# create server
+def openstack_create(endpoint, name)
+
+openstack server create [-h] [-f {shell,table}] [-c COLUMN]
+                               [--variable VARIABLE] [--prefix PREFIX] --image
+                               <image> --flavor <flavor>
+                               [--security-group <security-group-name>]
+                               [--key-name <key-name>]
+                               [--property <key=value>]
+                               [--file <dest-filename=source-filename>]
+                               [--user-data <user-data>]
+                               [--availability-zone <zone-name>]
+                               [--block-device-mapping <dev-name=mapping>]
+                               [--nic <nic-config-string>]
+                               [--hint <key=value>]
+                               <server-name>
+
+  image = "CentOS-7"
+  flavor = "gp1.semisonic"
+  keyname = "foo"
+  base(endpoint, "server create --key-name #{keyname}--image #{image} --flavor #{favor} #{id} -f shell")
+end
+
+# upload key
+def openstack_addkey(endpoint, name, key)
+  base(endpoint, "keypair create #{name} #{key}")
+end
+
+# remove key
+def openstack_deletekey(endpoint, name)
+  base(endpoint, "keypair delete #{name}")
+end
+
+# delete provided server
+def openstack_delete(endpoint, id)
+  base(endpoint, "server delete \'#{id}\'")
+end
+
+# reboot provided server
+def openstack_reboot(endpoint, id)
+  base(endpoint, "server reboot --hard \'#{id}\'")
+end
+
+# get list of servers
+def openstack_list(endpoint)
+  base(endpoint, "server list -f csv")
+end
+
+# get server details
+def openstack_get(endpoint, id)
+  base(endpoint, "server show \'#{id}\' -f csv")
+
+    os-dcf:diskconfig="AUTO"
+    os-ext-az:availability_zone="iad-2"
+    os-ext-sts:power_state="1"
+    os-ext-sts:task_state="None"
+    os-ext-sts:vm_state="active"
+    os-srv-usg:launched_at="2016-03-18T04:36:07.000000"
+    os-srv-usg:terminated_at="None"
+    accessipv4=""
+    accessipv6=""
+    addresses="public=208.113.135.196, 2607:f298:5:101d:f816:3eff:fe25:d05"
+    config_drive="True"
+    created="2016-03-18T04:35:57Z"
+    flavor="gp1.semisonic (50)"
+    hostid="2a74b475939b7e5956a2334e4ce2f5675340e0976778b53742aaec99"
+    id="9d5e5a03-5820-48e3-9bdf-f5ac18af4c64"
+    image="CentOS-7 (c1e8c5b5-bea6-45e9-8202-b8e769b661a4)"
+    key_name="rack1"
+    name="delete2"
+    os-extended-volumes:volumes_attached="[]"
+    progress="0"
+    properties=""
+    security_groups="[{u'name': u'default'}]"
+    status="ACTIVE"
+    tenant_id="ac8fccd077d04729b4cb5f85506bb336"
+    updated="2016-03-18T04:36:07Z"
+    user_id="b55909ea28574f479dc9cf5a9b673697"
+
+end
+
+private
+
+# find a flavor matching the requested type
+def find_flavor(endpoint, match)
+  favor(endpoint)[0]
+end
+
+# find an image matching the requested type
+def find_image(endpoint, match)
+  images(endpoint)[0]
+end
+
+# retrieve the flavors
+def flavors(endpoint)
+  base(endpoint, "openstack flavors list -f csv")
+end
+
+# retrieve the images
+def images(endpoint)
+  base(endpoint, "openstack images list -f csv")
+end
+
+# provide the base CLI interface with correct flags
+def base(endpoint, cmd)
+
+  cmd = "openstack --os-username \'#{endpoint['os-username']}\' " \
+                  "--os-password \'#{endpoint['os-password']}\' " \
+                  "--os-project-name \'#{endpoint['os-project-name']}\' " \
+                  "--os-region-name \'#{endpoint['os-region-name']}\' " \
+                  "--os-auth-url \'#{endpoint['os-auth-url']}\' " \
+                  "#{cmd}"
+
+end

--- a/containers/cloudwrap/cloudwrap/openstack.rb
+++ b/containers/cloudwrap/cloudwrap/openstack.rb
@@ -38,7 +38,7 @@ module OpenStack
 
   # remove key
   def self.deletekey(endpoint, name)
-    log "OpenStack removed key #{key}"
+    log "OpenStack removed key '#{name}'"
     base endpoint, "keypair delete \'#{name}\'"
   end
 

--- a/containers/cloudwrap/cloudwrap/waiter.rb
+++ b/containers/cloudwrap/cloudwrap/waiter.rb
@@ -25,6 +25,8 @@ loop do
       case ep['provider']
       when 'AWS', 'Google'
         servers[k["Key"]] = [rebar_id, endpoints[ep].servers.get(packet_device_id), endpoints[ep], ep]
+      when 'OpenStack'
+        log("PLACE HOLDER")
       when 'Packet'
         servers[k["Key"]] = [rebar_id, packet_device_id, nil, ep]
       end
@@ -55,6 +57,8 @@ loop do
           log "Server #{server.id} not ready, skipping"
           next
         end
+      when 'OpenStack'
+        log("PLACE HOLDER")
       when 'Packet'
         log "Testing server #{rebar_id} #{packet_device_id} state"
         response = nil
@@ -94,6 +98,8 @@ loop do
         private_dev_ip = server.private_ip_address
         private_dev_cidr = "32"
 
+      when 'OpenStack'
+        log("PLACE HOLDER")
       when 'Packet'
         # For now, make packet private and public the same.
         # The node can bind to either.
@@ -138,6 +144,8 @@ loop do
         answer = server.ssh("sudo -- ip addr | grep #{private_dev_ip} | awk '{ print $2 }' | awk -F/ '{ print $2 }'")
         private_dev_cidr = answer[0].stdout.strip
 
+      when 'OpenStack'
+        log("PLACE HOLDER")
       when 'Packet'
         log "Put keys to node"
         Tempfile.open("cloudwrap-keys") do |f|
@@ -174,8 +182,8 @@ loop do
       system("rebar nodes set #{rebar_id} attrib node-private-control-address to '{\"value\": \"#{private_dev_ip}/#{private_dev_cidr}\"}'")
       log "Marking server #{rebar_id} alive"
       Diplomat::Kv.delete(key)
-      Diplomat::Kv.delete("cloudwrap/keys/#{rebar_id}")
       system("rebar nodes update #{rebar_id} '{\"alive\": true, \"available\": true}'")
+      Diplomat::Kv.delete("cloudwrap/keys/#{rebar_id}")
       if ep && ep.respond_to?(:key_pairs)
         old_kp = ep.key_pairs.get(kp_name)
         old_kp.destroy if old_kp

--- a/containers/cloudwrap/cloudwrap/waiter.rb
+++ b/containers/cloudwrap/cloudwrap/waiter.rb
@@ -26,7 +26,7 @@ loop do
       when 'AWS', 'Google'
         servers[k["Key"]] = [rebar_id, endpoints[ep].servers.get(packet_device_id), endpoints[ep], ep]
       when 'OpenStack'
-        log("PLACE HOLDER")
+        servers[k["Key"]] = [rebar_id, openstack_device_id, nil, ep]
       when 'Packet'
         servers[k["Key"]] = [rebar_id, packet_device_id, nil, ep]
       end
@@ -58,7 +58,8 @@ loop do
           next
         end
       when 'OpenStack'
-        log("PLACE HOLDER")
+        log "Testing server #{rebar_id} #{openstack_device_id} state"
+        log "state check NOT implemented"
       when 'Packet'
         log "Testing server #{rebar_id} #{packet_device_id} state"
         response = nil

--- a/containers/cloudwrap/cloudwrap/waiter.rb
+++ b/containers/cloudwrap/cloudwrap/waiter.rb
@@ -240,7 +240,7 @@ loop do
 
         case endpoint['provider']
         when "OpenStack"
-          # OpenStack::deletekey endpoint, kp_name 
+          OpenStack::deletekey endpoint, kp_name 
         when 'Packet'
           # Packet endpoint has the account key
           packet_project_token = endpoint['project_token']

--- a/workloads/wl-lib.sh
+++ b/workloads/wl-lib.sh
@@ -285,7 +285,8 @@ add_provider() {
     \"os-project-name\": \"$PROVIDER_OS_PROJECT_NAME\",
     \"os-auth-url\": \"$PROVIDER_OS_AUTH_URL\",
     \"os-region-name\": \"$PROVIDER_OS_REGION_NAME\",
-    \"os-ssh-user\": \"$PROVIDER_OS_SSH_USER\"
+    \"os-ssh-user\": \"$PROVIDER_OS_SSH_USER\",
+    \"os-debug\": \"$PROVIDER_OS_DEBUG\"
   }
 }"
             rebar providers create "$provider"

--- a/workloads/wl-lib.sh
+++ b/workloads/wl-lib.sh
@@ -284,7 +284,8 @@ add_provider() {
     \"os-password\": \"$PROVIDER_OS_PASSWORD\",
     \"os-project-name\": \"$PROVIDER_OS_PROJECT_NAME\",
     \"os-auth-url\": \"$PROVIDER_OS_AUTH_URL\",
-    \"os-region-name\": \"$PROVIDER_OS_REGION_NAME\"
+    \"os-region-name\": \"$PROVIDER_OS_REGION_NAME\",
+    \"os-ssh-user\": \"$PROVIDER_OS_SSH_USER\"
   }
 }"
             rebar providers create "$provider"

--- a/workloads/wl-lib.sh
+++ b/workloads/wl-lib.sh
@@ -70,6 +70,12 @@ validate_provider() {
             error=1
         fi
         ;;
+    openstack)
+        if [ "$PROVIDER_OS_AUTH_URL" == "" ] ; then
+            echo "You must define PROVIDER_OS_AUTH_URL (can be added to ~/.dr_info)"
+            error=1
+        fi
+        ;;
     system|local)
         ;;
     *)
@@ -263,6 +269,22 @@ add_provider() {
     \"provider\": \"Google\",
     \"google_project\": \"$PROVIDER_GOOGLE_PROJECT\",
     \"google_json_key\": $PROVIDER_GOOGLE_JSON_KEY
+  }
+}"
+            rebar providers create "$provider"
+            ;;
+        openstack)
+            export PROVIDER_NAME="openstack-provider"
+            provider="{
+  \"name\": \"$PROVIDER_NAME\",
+  \"description\": \"OpenStack Provider\",
+  \"type\": \"OpenStackProvider\",
+  \"auth_details\": {
+    \"os-username\": \"$PROVIDER_OS_USERNAME\",
+    \"os-password\": \"$PROVIDER_OS_PASSWORD\",
+    \"os-project-name\": \"$PROVIDER_OS_PROJECT_NAME\",
+    \"os-auth-url\": \"$PROVIDER_OS_AUTH_URL\",
+    \"os-region-name\": \"$PROVIDER_OS_REGION_NAME\"
   }
 }"
             rebar providers create "$provider"


### PR DESCRIPTION
OpenStack Provider Interface (based on DreamHost)

This pull includes the initial working OpenStack Provider.  It was developed against the Dreamhost Cloud.  

It uses the python OpenStack CLI instead of trying to talk to the API directly.  This supposes that that CLI will be better supported than direct API calls or Fog.  That is included in the Dockerbuild file and will require an update to the Cloudwrap container.

Since this only tested one cloud, there will be changes as we add more cloud instances.  However, I've made attempts to handle variation in images & flavors between clouds.

The OpenStack code is wrapped in a dedicated class to minimize complexity.  Some refactoring of the Waiter.rb was needed to mix code w/ Packet.

Requires DigitalRebar Core #1128