### PR TITLE
add network awareness for OpenStack provider using neutron CLI

### DIFF
--- a/containers/cloudwrap/Dockerfile
+++ b/containers/cloudwrap/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get -y update && \
     apt-add-repository ppa:brightbox/ruby-ng && \
     add-apt-repository "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-backports main restricted universe multiverse" && \
     apt-get -y update && \
-    apt-get -y install ruby2.2 ruby2.2-dev make cmake curl build-essential jq libxml2-dev libcurl4-openssl-dev libssl-dev python-openstackclient && \
+    apt-get -y install ruby2.2 ruby2.2-dev make cmake curl build-essential jq libxml2-dev libcurl4-openssl-dev libssl-dev python-openstackclient python-neutronclient && \
     gem install bundler && \
     mkdir -p /var/cache/cloudwrap/gems
 

--- a/containers/cloudwrap/cloudwrap/waiter.rb
+++ b/containers/cloudwrap/cloudwrap/waiter.rb
@@ -112,7 +112,8 @@ loop do
 
       when 'OpenStack'
 
-        dev_ip = OpenStack::public_v4(device_data['addresses'])
+        addresses = OpenStack::addresses(device_data['addresses'])
+        dev_ip = addresses["public"][:v4] rescue "public_v4_not_defined"
         cidr = "32"
         username = nil
         users = (endpoint['os-ssh-user'] || "ubuntu centos root").split(/\s|,/)
@@ -131,9 +132,9 @@ loop do
           end
         end
 
-        # MISSING for Now!  Using Public IP.
-        private_dev_ip = dev_ip
+        private_dev_ip = addresses["private"][:v4] rescue "private_v4_not_defined"
         private_dev_cidr = "32"
+        log "OpenStack server public IP #{dev_ip} & private IP #{private_dev_ip}"
 
       when 'Packet'
         # For now, make packet private and public the same.


### PR DESCRIPTION
To create networks with the OpenStack CLI, I had to include the GUIDs that are available only from the Neutron CLI.  This update includes adding the Neutron CLI to the apt-get instructions.

Then I wrapped neutron in a generic way for the networks list.

At this time, it's hard coded to use public and private.  It also requires you to have both networks.  

Will fix that in the next pull.