### PR TITLE
continue to tweak based on cloud behaviors

### DIFF
--- a/containers/cloudwrap/cloudwrap/openstack.rb
+++ b/containers/cloudwrap/cloudwrap/openstack.rb
@@ -137,7 +137,7 @@ module OpenStack
     o = netbase endpoint, "net-list", "-f csv"
     r = uncsv(o, "id")
     # HACK remove networks without active subnets - detect because the only have a 36 char subnet GUID
-    r.delete_if { |v, k| k["subnets"].size < 40}
+    r.delete_if { |v, k| k["subnets"].b.gsub(/[a-f0-9-]+ /, '').size < 10}
     log "OpenStack networks DEBUG hash: #{r.inspect}" if os_debug(endpoint)
     return r
 
@@ -253,7 +253,7 @@ module OpenStack
   # to handle variation w/ OpenStack clouds, we have to reolve several possible names for public or private networks
   # order should be in likehood of correct match
   def self.public_net(nets)
-    return network(nets, %w[public ext-net external pub ext])
+    return network(nets, %w[public ext-net external default pub ext])
   end
 
   # parse raw shell output

--- a/containers/cloudwrap/cloudwrap/waiter.rb
+++ b/containers/cloudwrap/cloudwrap/waiter.rb
@@ -196,6 +196,7 @@ loop do
             Net::SCP.upload!(dev_ip, username, f.path, "/tmp/rebar_keys", { ssh: { keys: [ kp_loc ], paranoid: false } })
           rescue Exception => e
             log "Server #{cloudwrap_device_id} failed to upload keys, skipping: #{e}"
+            system("rebar nodes set #{rebar_id} attrib node-control-address to '{\"value\": \"0.0.0.0/24\"}'")
             next
           end
         end
@@ -224,6 +225,7 @@ loop do
           end
         rescue Exception => e
           log "Server #{cloudwrap_device_id} not key updatable, skipping: #{e}"
+          system("rebar nodes set #{rebar_id} attrib node-control-address to '{\"value\": \"0.0.0.0/32\"}'")
           next
         end
       end


### PR DESCRIPTION
Found issue w/ net elimination script - this handles when there is >1 subnet.

Also, provide a little more feedback (0s in IP) if we can't ssh into a system.  This happens when the IPs given are not public.