### PR TITLE
allow users to pre-cache tftpboot locally and then upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 /.vagrant/
 /compose/digitalrebar
 
+# upload tftpboot to .cache/digitalrebar stored here
+/tftpboot
+
 .#*
 *~
 *.dia.autosave

--- a/tasks/compose.yml
+++ b/tasks/compose.yml
@@ -51,13 +51,11 @@
 
   - name: Make cache dirs
     command: mkdir -p {{home_dir.stdout}}/.cache/digitalrebar/tftpboot/isos
+    when: "'--provisioner' in dr_services"
 
-  - stat: path={{home_dir.stdout}}/digitalrebar/isos/*.iso
-    register: local_isos
-
-  - name: push ISO from local ~/digitalrebar/isos (FAST LOCAL but SLOW REMOTE!)
-    synchronize: src="../isos/" dest="{{home_dir.stdout}}/.cache/digitalrebar/tftpboot/isos/" rsync_path="rsync"
-    when: local_isos is defined and "'--provisioner' in dr_services"
+  - name: push tftpboot cache files (ISOs) from local tftpboot (FAST LOCAL but SLOW REMOTE!)
+    synchronize: src=./tftpboot dest={{home_dir.stdout}}/.cache/digitalrebar rsync_path="rsync"
+    when: "'--provisioner' in dr_services"
     ignore_errors: yes
 
   - name: download Ubuntu ISO (SLOW, see https://github.com/digitalrebar/core/blob/develop/barclamps/provisioner.yml)


### PR DESCRIPTION
instead of just pushing ISOs, it makes sense to allow users to pre-cache their whole TFTPboot path for local installs.  This simplifies the upload and creates the working directory.