### PR TITLE
all in one dockerfile to install kubernetes from docker run

### DIFF
--- a/fast/kubernetes/Dockerfile
+++ b/fast/kubernetes/Dockerfile
@@ -1,0 +1,33 @@
+FROM williamyeh/ansible:ubuntu16.04
+MAINTAINER Rob Hirschfeld <rob@rackn.com>
+ENTRYPOINT ["workloads/kubernetes.sh"]
+
+RUN apt-get update && \
+    apt-get install git sudo unzip jq curl python python-pymongo python-pycurl -y
+
+# Rebar Deploy Code
+RUN mkdir digitalrebar && \
+    git clone https://github.com/rackn/digitalrebar-deploy /root/digitalrebar/deploy
+WORKDIR /root/digitalrebar/deploy
+
+# Rebar CLI
+RUN curl -o /usr/local/sbin/rebar https://s3-us-west-2.amazonaws.com/rebar-cli/rebar-linux-amd64 && \
+    chmod +x /usr/local/sbin/rebar
+
+# Assuming AWS, we'll preinstall the AWS tools
+RUN curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && \
+            unzip awscli-bundle.zip && \
+            sudo ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \
+            rm -rf awscli-bundle*
+
+# Where are you running Digital Rebar?  aws, google, packet, etc.
+ENV DEPLOY_ADMIN aws
+
+# Where are you running your cluster? aws, google, packet, etc
+ENV PROVIDER=aws
+
+# CUSTOMIZE YOUR PROVIDER AND ACCESS in your client local .dr_info file!  
+# See http://digital-rebar.readthedocs.io/en/latest/deployment/install/dr_info.html 
+# Build this file: $IMAGE = docker build .
+# Then: docker run -it -v ~/.dr_info:/root/.dr_info $IMAGE 
+RUN echo "next step: docker run -it -v ~/.dr_info:/root/.dr_info $IMAGE"


### PR DESCRIPTION
This is WIP - it seems to be having trouble w/ AWS keygen.  

To use, docker build fast/kubernetes
Then docker run -it -v ~/.dr_info:/root/.dr_info $IMAGE

This is "just work" if you have created a .dr_info file.