### PR TITLE
Rework how we register revproxy services -- REVIEW ONLY

### DIFF
--- a/compose/init_files.sh
+++ b/compose/init_files.sh
@@ -4,7 +4,7 @@ if which sudo 2>/dev/null >/dev/null ; then
     SUDO=sudo
 fi
 
-SERVICES="network-server rebar-api_service logging-service"
+SERVICES="network-server logging-service"
 
 function usage {
     echo "Usage: $0 <flags> [options docker-compose flags/commands]"

--- a/containers/base/docker-entrypoint.sh
+++ b/containers/base/docker-entrypoint.sh
@@ -27,12 +27,23 @@ get_service() {
 make_service() {
     # $1 = service name.
     # $2 = port to check on
-    # $3 = check fragment
+    # $3 = check fragment%s
     if [[ $FORWARDER_IP ]]; then
         printf '{"name":"internal-%s-service","port":%s,"tags":["deployment:%s"],"check":%s}' "$1" "$2" "$SERVICE_DEPLOYMENT" "$3"
     else
         printf '{"name":"%s-service","port":%s,"address":"%s","tags":["deployment:%s"],"check":%s}' "$1" "$2" "${EXTERNAL_IP%%/*}" "$SERVICE_DEPLOYMENT" "$3"
     fi | curl -X PUT http://localhost:8500/v1/agent/service/register --data-binary @-
+}
+
+make_revproxied_service() {
+    # $1 = service name.
+    # $2 = port to check on
+    # $3 = check fragment
+    local name="${1%-mgmt}"
+    printf '^%s/(.*)' "$name" |kv_put "digitalrebar/public/revproxy/${1}-service/matcher"
+    printf '{"name":"%s-service","port":%s,"tags":["revproxy", "deployment:%s"],"check":%s}' "$1" "$2" "$SERVICE_DEPLOYMENT" "$3" | \
+        curl -X PUT http://localhost:8500/v1/agent/service/register --data-binary @-
+    
 }
 
 bind_service() {

--- a/containers/provisioner/entrypoint.d/60-bind-services.sh
+++ b/containers/provisioner/entrypoint.d/60-bind-services.sh
@@ -1,13 +1,9 @@
 #!/bin/bash
 
 prov_url="http://${EXTERNAL_IP%%/*}:${WEBPORT}"
-mgmt_url="https://${EXTERNAL_IP%%/*}:${APIPORT}"
 
 set_service_attrib provisioner-service provisioner-default-boot-program \
  "{\"value\": \"$PROVISIONER_BOOT_PROGRAM\"}"
 
 set_service_attrib provisioner-service provisioner-webservers \
  "{\"value\": [{\"url\": \"$prov_url\", \"address\": \"${EXTERNAL_IP%%/*}\", \"port\": $WEBPORT}]}"
-
-set_service_attrib provisioner-service provisioner-management-servers \
- "{\"value\": [{\"url\": \"$mgmt_url\", \"address\": \"${EXTERNAL_IP%%/*}\", \"port\": $APIPORT}]}"

--- a/containers/provisioner/entrypoint.d/80-register-consul-services.sh
+++ b/containers/provisioner/entrypoint.d/80-register-consul-services.sh
@@ -1,14 +1,7 @@
 #!/bin/bash
 make_service "provisioner" $WEBPORT '{"script": "pidof sws", "interval": "10s"}'
 
-
-# Add rev-proxy matcher
-echo '^provisioner/(.*)' | kv_put digitalrebar/public/revproxy/provisioner-mgmt-service/matcher
-
-OSD=$SERVICE_DEPLOYMENT
-SERVICE_DEPLOYMENT="$OSD\", \"revproxy"
-make_service "provisioner-mgmt" $APIPORT '{"script": "pidof provisioner-mgmt","interval": "10s"}'
-SERVICE_DEPLOYMENT=$OSD
+make_revproxied_service "provisioner-mgmt" $APIPORT '{"script": "pidof provisioner-mgmt","interval": "10s"}'
     
 make_service "provisioner-tftp" 69 '{"script": "pidof sws","interval": "10s"}'
 

--- a/containers/rebar-api/entrypoint.d/22-set-entrypoint-for-everything-else.sh
+++ b/containers/rebar-api/entrypoint.d/22-set-entrypoint-for-everything-else.sh
@@ -11,7 +11,7 @@
     cat >/etc/rebar-data/rebar-key.sh <<EOF
 export REBAR_KEY="$REBAR_KEY"
 export REBAR_ENDPOINT="https://${IP}:3000"
-export EXTERNAL_REBAR_ENDPOINT="https://${EXTERNAL_IP%%/*}:3000"
+export EXTERNAL_REBAR_ENDPOINT="https://${EXTERNAL_IP%%/*}"
 EOF
     kv_put digitalrebar/private/api/keys/rebar_key </etc/rebar-data/rebar-key.sh
 )

--- a/containers/rebar-api/entrypoint.d/23-wait-for-api-to-start.sh
+++ b/containers/rebar-api/entrypoint.d/23-wait-for-api-to-start.sh
@@ -6,10 +6,10 @@ done
 
  
 # Add rev-proxy matcher
-echo '^rebarapi/(.*)' | kv_put digitalrebar/public/revproxy/rebar-api-service/matcher
-
 OSD=$SERVICE_DEPLOYMENT
-SERVICE_DEPLOYMENT="$OSD\", \"revproxy\", \"revproxy-default"
-make_service rebar-api 3000 '{"script": "rebar -E $REBAR_ENDPOINT -U rebar -P rebar1 ping","interval": "10s"}'
+SERVICE_DEPLOYMENT="$OSD\", \"revproxy-default"
+make_revproxied_service "rebar-api" 3000 '{"script": "rebar -T -E $REBAR_ENDPOINT -U system ping","interval": "10s"}'
 SERVICE_DEPLOYMENT=$OSD
+
+
 

--- a/containers/rebar-api/entrypoint.d/24-build-initial-machine-keys.sh
+++ b/containers/rebar-api/entrypoint.d/24-build-initial-machine-keys.sh
@@ -15,7 +15,7 @@ if ! rebar -U rebar -P rebar1 users show machine-install; then
   \"digest\": true
 }"
 
-    if ! rebar -U rebar -P rebar1 -E https://127.0.0.1:3000 users import "$machine_user"; then
+    if ! rebar -U rebar -P rebar1 users import "$machine_user"; then
         echo "Could not create machine-install user!"
         exit 1
     fi
@@ -23,7 +23,7 @@ if ! rebar -U rebar -P rebar1 users show machine-install; then
     for cap in NODE_READ ROLE_READ NODE_CREATE NODE_UPDATE NODE_COMMIT \
                          DEPLOYMENT_READ DEPLOYMENT_UPDATE PROVIDER_READ; do
         blob="{\"user_id\":\"machine-install\",\"tenant_id\":\"system\",\"capability_id\":\"$cap\"}"
-        rebar -U rebar -P rebar1 -E https://127.0.0.1:3000 user_tenant_capabilitys create "$blob"
+        rebar -U rebar -P rebar1 user_tenant_capabilitys create "$blob"
     done
 
     echo "machine-install:${MACHINE_PASSWORD}" >/etc/rebar.install.key

--- a/containers/rebar-api/entrypoint.d/27-bind-rebar_api-service.sh
+++ b/containers/rebar-api/entrypoint.d/27-bind-rebar_api-service.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
 if [[ -f $BUILT_CFG_FILE ]]; then
-    # Add keys into the system
-    bind_service rebar-api_service
     rebar deployments bind system to rebar-access || :
     keys=`jq -r .ssh_keys ${BUILT_CFG_FILE}`
     set_service_attrib rebar-access rebar-access_keys "{ \"value\": $keys }"

--- a/containers/rebar-dhcp/entrypoint.d/20-start-dhcp.sh
+++ b/containers/rebar-dhcp/entrypoint.d/20-start-dhcp.sh
@@ -15,14 +15,7 @@ HOSTS="$HOSTS,$CI_IP"
 
 # Service has to start first - or we should move the consul stuff into the app.
 run_forever /usr/local/bin/rebar-dhcp --server_ip=$EXTERNAL_IP --backing_store=consul --data_dir=digitalrebar/dhcp/database --auth_mode=KEY --host="$HOSTS" &
-
-# Add rev-proxy matcher
-echo '^dhcp/(.*)' | kv_put digitalrebar/public/revproxy/dhcp-mgmt-service/matcher
-
 make_service dhcp 67 '{"script": "pidof rebar-dhcp","interval": "10s"}'
+make_revproxied_service dhcp-mgmt  6755 '{"script": "pidof rebar-dhcp","interval": "10s"}'
 
-OSD=$SERVICE_DEPLOYMENT
-SERVICE_DEPLOYMENT="$OSD\", \"revproxy"
-make_service dhcp-mgmt  6755 '{"script": "pidof rebar-dhcp","interval": "10s"}'
-SERVICE_DEPLOYMENT=$OSD
 

--- a/containers/rebar-dhcp/entrypoint.d/40-update-consul.sh
+++ b/containers/rebar-dhcp/entrypoint.d/40-update-consul.sh
@@ -1,13 +1,5 @@
 #!/bin/bash
 
-attr="{\"value\": [{
-       \"address\": \"${EXTERNAL_IP%%/*}\",
-       \"port\": \"6755\",
-       \"name\": \"$SERVICE_DEPLOYMENT\",
-       \"url\": \"https://${EXTERNAL_IP%%/*}:6755\"
-      }]
-}"
 # Make sure we set the token type
 set_service_attrib dhcp-service dhcp_servers "{\"value\": [\"${EXTERNAL_IP%%/*}\"]}"
-set_service_attrib dhcp-mgmt_service dhcp-management-servers "$attr"
 

--- a/containers/rebar-rev-proxy/entrypoint.d/27-start-services.sh
+++ b/containers/rebar-rev-proxy/entrypoint.d/27-start-services.sh
@@ -38,7 +38,8 @@ run_forever() (
   done
 )
 
-run_forever /usr/local/bin/rebar-rev-proxy --externalIp ${EXTERNAL_IP%%/*} \
+make_service "rebar-rev-proxy" $REVPROXY_PORT '{"script": "pidof rebar-rev-proxy", "interval": "10s"}'
+/usr/local/bin/rebar-rev-proxy --externalIp ${EXTERNAL_IP%%/*} \
 	$FORWARDER_FLAG \
 	$LISTENPORT \
 	$AUTHFILTER \
@@ -46,7 +47,8 @@ run_forever /usr/local/bin/rebar-rev-proxy --externalIp ${EXTERNAL_IP%%/*} \
 	--host "$IP,${EXTERNAL_IP%%/*},${HOSTNAME},127.0.0.1,localhost" \
 	$SAMLCERT \
 	$SAMLIDPSSOURL \
-	$SAMLIDPSSODESCURL &
+	$SAMLIDPSSODESCURL && exit 0
+exit 1
 
-make_service "rebar-rev-proxy" $REVPROXY_PORT '{"script": "pidof rebar-rev-proxy", "interval": "10s"}'
+
 

--- a/containers/rebar-rev-proxy/rebar-rev-proxy/digest.go
+++ b/containers/rebar-rev-proxy/rebar-rev-proxy/digest.go
@@ -7,7 +7,7 @@ import (
 	"math/rand"
 	"net/http"
 
-	"github.com/kmanley/go-http-auth"
+	auth "github.com/kmanley/go-http-auth"
 )
 
 func getUserString(tlsConfig *tls.Config, user, data string) string {
@@ -19,7 +19,8 @@ func getUserString(tlsConfig *tls.Config, user, data string) string {
 
 	tag, err := ServiceRegistry.ExtractTag(req.URL)
 	if err != nil {
-		log.Printf("Failed to extract Tag: %v\n", err)
+
+		log.Printf("Failed to extract Tag of %s: %v\n", req.URL, err)
 		return ""
 	}
 	endpoints, err := ServiceRegistry.LookupTag(tag)

--- a/containers/rebar-rev-proxy/rebar-rev-proxy/registry.go
+++ b/containers/rebar-rev-proxy/rebar-rev-proxy/registry.go
@@ -216,8 +216,10 @@ func (c *ConsulRegistry) WatchConsul() {
 				log.Printf("kv lookup err: %v", err)
 			} else {
 				if kp != nil && kp.Value != nil {
+					log.Printf("%s: Using matcher regexp from Consul: %s", svcTag, string(kp.Value))
 					svcMatcher = string(kp.Value[:])
 				} else {
+					log.Printf("%s: Using default matcher ^%s/(.*)", svcTag, svcTag)
 					svcMatcher = "^" + svcTag + "/(.*)"
 				}
 			}


### PR DESCRIPTION
Create a make_revproxied_service helper in docker-entrypoint, and fix
everything up to use it to register services that should be exposed via
the revproxy instead of the forwarder.