### PR TITLE
Always rebuild bower, because we don't have all the components

### DIFF
--- a/compose/common.env
+++ b/compose/common.env
@@ -117,7 +117,7 @@ PROVISIONER_BOOT_PROGRAM=lpxelinux
 #REVPROXY_SAML_IDP_CERT_FILE=/etc/rev-proxy/saml-dir/idpcert.crt
 
 # Uncommment to cause bower to be rebuilt on container start.
-#REVPROXY_REBUILD_BOWER=true
+REVPROXY_REBUILD_BOWER=true
 
 #
 # Number of background workers to run in parallel for annealing tasks.


### PR DESCRIPTION
in the container.